### PR TITLE
feat: Pentagram - 충돌 방지용 quadtree 구조체 추가

### DIFF
--- a/src/feature/Pentagram/hooks/store/useHandleDrag.ts
+++ b/src/feature/Pentagram/hooks/store/useHandleDrag.ts
@@ -6,6 +6,7 @@ import { setSelectedPosition, updatePosition } from "$feature/Pentagram/store/pe
 
 import { getAngleAndDisctance } from "../../utils"
 import { PENTAGRAM } from "../../constants"
+import { Quadtree, quadtreeRoot } from "../../utils/quadtree"
 
 export function useHandleDrag(parentElem: HTMLDivElement | null) {
     const { selected } = useSelector((state: AppRootState) => state.pentagramUpsert)
@@ -18,16 +19,23 @@ export function useHandleDrag(parentElem: HTMLDivElement | null) {
         const { angle, distance } = getAngleAndDisctance(e, parentElem, PENTAGRAM.SIDES)
         if (typeof angle !== 'number' || typeof distance !== 'number') return
 
+        const colliding = Quadtree.checkCollidingByPosition(quadtreeRoot, {
+            angle, 
+            distance, 
+        })
+        
+        if (colliding) return
+
         if (selected.nodeType === 'node') {
             throttle(
                 () => dispatch(updatePosition({ angle, distance}))
-            , 200)
+            , 25)
         }
 
         if (selected.nodeType === 'idle') {
             throttle(
                 () => dispatch(setSelectedPosition({ angle, distance }))
-            , 200)
+            , 25)
         }
     }
 

--- a/src/feature/Pentagram/store/pentagramUpsertSlice/upsert.ts
+++ b/src/feature/Pentagram/store/pentagramUpsertSlice/upsert.ts
@@ -4,6 +4,7 @@ import type { UpdateNodeState } from "."
 
 import { PENTAGRAM } from "$feature/Pentagram/constants"
 import { pendingNodeAdapter, nodeAdapter } from "."
+import { Quadtree, quadtreeRoot } from "../../utils/quadtree"
 
 interface UpsertPayload {
     distance: number
@@ -25,7 +26,6 @@ export const upsert = (
     state: UpdateNodeState, 
     payload: UpsertNodePayload | UpsertPendingNodePayload
 ) => {
-    
     const { nodeType } = payload
     if (nodeType === 'node') {
         upsertNode(state, payload)
@@ -48,6 +48,12 @@ const upsertNode = (
         oeuvres,
         originalNode
     })
+
+    Quadtree.insertNodeByPosition(quadtreeRoot, {
+        id,
+        angle,
+        distance
+    })
 }
 
 const upsertPendingNode = (
@@ -55,10 +61,18 @@ const upsertPendingNode = (
     payload: UpsertPendingNodePayload
 ) => {
     const { oeuvres, angle, distance } = payload
+    
+    const id =  String(state.pendingNode.ids.length + PENTAGRAM.PENDING_NODE_OFFSET)
     pendingNodeAdapter.upsertOne(state.pendingNode, {
+        id,
         oeuvres,
         angle,
         distance,
-        id: String(state.pendingNode.ids.length + PENTAGRAM.PENDING_NODE_OFFSET)
+    })
+
+    Quadtree.insertNodeByPosition(quadtreeRoot, {
+        id,
+        angle,
+        distance
     })
 }

--- a/src/feature/Pentagram/utils/quadtree.ts
+++ b/src/feature/Pentagram/utils/quadtree.ts
@@ -1,0 +1,179 @@
+// https://github.com/timohausmann/quadtree-ts의 코드를 상황에 맞게 변형함
+
+import { PENTAGRAM } from "../constants"
+
+export type QuadtreeNode = {
+    objects: Bounds[]
+    nodes: QuadtreeNode[]
+    bounds: Bounds
+    level: number,
+    maxDepth: number
+}
+
+type Bounds = {
+    id?: string,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+}
+
+type Position = {
+    angle: number,
+    distance: number,
+    id?: string | undefined
+}
+
+type PositionWithId = Position & {
+    id: string
+}
+
+export class Quadtree {
+    static insertNodeByPosition(qtNode: QuadtreeNode, position: PositionWithId) {
+        const bound = Quadtree.calcBound(position)
+        Quadtree.insert(qtNode, bound)
+    }
+
+    static checkCollidingByPosition(qtNode: QuadtreeNode, position: Position) {
+        const obj = Quadtree.calcBound(position)
+        const collidable = Quadtree.retrieve(qtNode, obj)
+
+        return collidable.some((b) => Quadtree.checkColliding(b, obj))
+    }
+
+    static createNode(bounds:Bounds, level=0, maxDepth=9): QuadtreeNode {
+        return {
+            level,
+            bounds,
+            maxDepth,
+            objects: [],
+            nodes: [],
+        }
+    }
+
+    private static checkColliding(bound: Bounds, obj: Bounds) {
+        const objX = obj.x + (obj.width / 2)
+        const objY = obj.y + (obj.height / 2)
+        const boundX = bound.x + (bound.width / 2)
+        const boundY = bound.y + (bound.height / 2)
+        
+        const dist = Quadtree.getDistance(objX, objY, boundX, boundY)
+        if (dist < obj.width*Math.sqrt(2) + bound.width * Math.sqrt(2)) {
+            return true
+        }
+        return false
+    }
+
+    private static getIndice(qtNode: QuadtreeNode, obj: Bounds): number[] {
+        const { x: oldX, y: oldY, width: oldWidth, height: oldHeight } = qtNode.bounds
+        const width = oldWidth / 2
+        const height = oldHeight / 2
+
+        const qtIndice = []
+        for (let i = 0; i < 4; i++) {
+            const bound = {
+                width,
+                height,
+                x: oldX + width * (i%2),
+                y: oldY + height * Math.floor(i/2),
+            }
+
+            if (Quadtree.checkColliding(bound, obj)) {
+                qtIndice.push(i)
+            }
+        }
+        
+        return qtIndice
+    }
+
+    private static split(qtNode: QuadtreeNode) {
+        const level = qtNode.level + 1
+        const { x: oldX, y: oldY, width: oldWidth, height: oldHeight } = qtNode.bounds
+        const width = oldWidth / 2
+        const height = oldHeight / 2
+
+        for (let i = 0; i < 4; i++) {
+            qtNode.nodes.push(
+                Quadtree.createNode({
+                    width,
+                    height,
+                    x: oldX + width * (i%2),
+                    y: oldY + height * Math.floor(i/2),
+                }, level)
+            )
+        }
+    }
+
+    private static insert(qtNode: QuadtreeNode, obj:Bounds): void {
+        if (qtNode.maxDepth === qtNode.level) return // 같은 좌표의 경우 재귀 탈출 불가
+
+        if (!qtNode.objects.length && !qtNode.nodes.length) {
+            qtNode.objects.push(obj)
+            return
+        }
+
+        if (qtNode.objects.some((item) => item.id === obj.id)) return
+        
+        if (!qtNode.nodes.length) {
+            Quadtree.split(qtNode)
+        }
+
+        const indice = Quadtree.getIndice(qtNode, obj)
+
+        if (qtNode.nodes.length) {
+            indice.forEach((index) => {
+                Quadtree.insert(qtNode.nodes[index], obj)
+                qtNode.objects.forEach((o) => {
+                    Quadtree.insert(qtNode.nodes[index], o)
+                })
+            })
+        }
+
+        qtNode.objects = []
+    }
+
+    private static retrieve(qtNode: QuadtreeNode, obj: Bounds) {
+        let returnObjects = [...qtNode.objects]
+        
+        const indice = Quadtree.getIndice(qtNode, obj)
+
+        if (qtNode.nodes.length) {
+            indice.forEach((index) => {
+                returnObjects = returnObjects.concat(
+                    Quadtree.retrieve(qtNode.nodes[index], obj)
+                )
+            })
+        }
+
+        if (qtNode.level === 0) {
+            return Array.from(new Set(returnObjects))
+        }
+
+        return returnObjects
+    }
+
+    private static getDistance(x1: number, y1: number, x2: number, y2:number) {
+        return ((x2-x1) ** 2 + (y2-y1) ** 2) ** 0.5
+    }
+
+    private static calcBound(position: Position) {
+        const angle = position.angle + PENTAGRAM.ANGLE_OFFSET
+        const x = Math.cos(angle * Math.PI / PENTAGRAM.HALF_CIRCLE) * position.distance + 100
+        const y = Math.sin(angle * Math.PI / PENTAGRAM.HALF_CIRCLE) * position.distance + 100
+        const size = 10
+        return {
+            x: x-(size/2),
+            y: y-(size/2),
+            id: position.id,
+            width: size,
+            height: size
+        }
+    }
+}
+
+export const quadtreeRoot = Quadtree.createNode({
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 200
+})


### PR DESCRIPTION
#### 1. quadtree의 필요성
- 노드의 **위치를 수정**시키기 위해 **충돌 검사** 필요
- 나이브하게 구현할 경우 매 이동 시에 모든 노드에 대한 거리 계산 필요
  - 일반적인 상황에서 나이브한 구현으로 충분함(노드 100개 이내를 가정)
- 특수한 상황을 대비할 필요
  - 이동 가능한 좌표를 보여주는 기능
  - 가능한 모든 좌표쌍(360 * 100)에 대해 노드 개수만큼 계산해야 함
  - 드래그 시에 실시간으로 계산해야 함
- 이러한 상황으로 인해 시간 복잡도가 개선된 자료 구조가 필요함

#### 2. quadtree의 문제점
- `redux` 관련 이슈
  - `redux`에서 사용하기 위해서는 `class 구현체`가 아닌 `POJO`여야 함
  - 대부분의 라이브러리는 `class` 기반 구현체임
  - `POJO`의 경우에도 깊은 복사가 너무 자주 일어남
- 반-선언적인(anti-declartive) 패턴
  - 리액트의 기반인 단일한 **상태**를 해침
  - `redux`의 노드 상태와 `quadtree`의 충돌 관련 정보는 별개로 존재함
  - 삭제 및 추가 시에 `redux` 상태와 분기되는데, 이를 잡아주기 위해 별도의 `명령적 절차`가 필요 