### PR TITLE
feat: 인포 카드 템플릿 추가

### DIFF
--- a/src/feature/template/components/InfoCardTemplate.tsx
+++ b/src/feature/template/components/InfoCardTemplate.tsx
@@ -1,0 +1,64 @@
+import type { ISlotComponent, ISlotOption } from "../type"
+import type { MouseEventHandler } from "react"
+import { filterComponents } from "../util"
+import "./style/infoCard.scss"
+
+export type InfoCardKey = "coverImage" | "title" | "mainInfo" | "subInfo"
+export type InfoCardOptions = ISlotOption<InfoCardKey>
+
+type InfoCardProps = {
+    id: string,
+    components: ISlotComponent<InfoCardKey>,
+    options?: InfoCardOptions,
+    onClick?: MouseEventHandler<HTMLDivElement>
+}
+
+export default function InfoCardTemplate (props: InfoCardProps) {
+    const { components, options, ...restProps } = props
+    const filteredComponents = filterComponents<InfoCardKey>(components, options)
+
+    return (
+        <div 
+            {...restProps}
+            className="info-card-template"
+        >
+            {filteredComponents?.coverImage &&
+                <div className="info-card-template__cover-outer-container">
+                    <div className="info-card-template__cover-inner-container">
+                        {filteredComponents.coverImage}
+                    </div>
+                </div>
+            }
+            {
+                (filteredComponents.title ||
+                filteredComponents.mainInfo ||
+                filteredComponents.subInfo) &&
+                    <div className="info-card-template__main-container">
+                        {filteredComponents.title &&
+                            <div className="info-card-template__title">
+                                {filteredComponents.title}
+                            </div>
+                        }
+                        {(
+                            (filteredComponents?.mainInfo) ||
+                            (filteredComponents?.subInfo)
+                        ) &&
+                            <div className="info-card-template__info-container">
+                                {filteredComponents.mainInfo &&
+                                    <div className="info-card-template__main-info">
+                                        {filteredComponents.mainInfo}
+                                    </div>
+                                }
+                                {filteredComponents.subInfo &&
+                                    <div className="info-card-template__sub-info">
+                                        {filteredComponents.subInfo}
+                                    </div>
+                                }
+                            </div>
+                        }
+                    </div>
+            }
+        </div>
+    )
+}
+

--- a/src/feature/template/components/style/infoCard.scss
+++ b/src/feature/template/components/style/infoCard.scss
@@ -1,0 +1,41 @@
+@import "src/lib/style/atomicMixin";
+
+.info-card-template {
+    @include flex;
+    @include child-left-m(var(--base-size));
+    .info-card-template__cover-outer-container {
+        @include flex;
+        @include align-center;
+        min-width: 30%;
+        max-width: 30%;
+        .info-card-template__cover-inner-container {
+            @include box-shadow-2(rgb(var(--font-color)));
+            @include rounded-lg;
+            aspect-ratio: 1;
+            width: 100%;
+            object-fit: cover;
+        }
+    }
+
+    .info-card-template__main-container {
+        @include flex-col;
+        @include justify-center;
+        @include child-top-m(calc(var(--base-size) * 0.5));
+        flex-basis: 1;
+        .info-card-template__title {
+            font-size: calc(var(--base-size) * 1.3);
+        }
+
+        .info-card-template__info-container {
+            @include child-top-m(calc(var(--base-size) * 0.5));
+            .info-card-template__main-info {
+                font-size: calc(var(--base-size) * 0.8);
+            }
+
+            .info-card-template__sub-info {
+                font-size: calc(var(--base-size) * 0.7);
+                line-height: calc(var(--base-size) * 1.2);
+            }
+        }
+    }
+}

--- a/src/feature/template/type.ts
+++ b/src/feature/template/type.ts
@@ -1,0 +1,3 @@
+export type ISlotItem = React.JSX.Element | string | undefined | null
+export type ISlotComponent<K extends string> = Record<K, ISlotItem>
+export type ISlotOption<K extends string> = Record<K, (boolean | undefined)>

--- a/src/feature/template/util/index.ts
+++ b/src/feature/template/util/index.ts
@@ -1,0 +1,15 @@
+import type { ISlotComponent, ISlotOption } from "../type"
+
+export function filterComponents<K extends string>(components: ISlotComponent<K>, options: ISlotOption<K> | undefined){
+    const filteredObject = {} as ISlotComponent<K>
+    if (!options) return filteredObject
+
+    const keys = Object.keys(options) as K[] 
+    keys.forEach((key) => {
+        if (!options[key]) return
+        if (!components[key]) return
+        filteredObject[key] = components[key]
+    })
+
+    return filteredObject;
+}


### PR DESCRIPTION
- 사용자 프로필, 작품 정보, 작가 정보, 카테고리 정보 등 공용 사용
- 스벨트, 뷰 등의 네임드 슬롯 기능을 유사하게 구현
- 호출 컴포넌트를 명시함으로써 추상화와 가시성의 균형 모색