### PR TITLE
fix: 미니 프로필, 프로필 셀렉트 뷰 컴포넌트에서 부적절한 이벤트 핸들러 수정

### DIFF
--- a/src/feature/Profile/components/MiniProfile.tsx
+++ b/src/feature/Profile/components/MiniProfile.tsx
@@ -28,8 +28,8 @@ export default function MiniProfile(props: FormatProps<DBMiniProfile> & { displa
                     displayInteraction: false,
                 }}
                 eventHandler={{
-                    ...navigate,
-                    handleFollow
+                    handleFollow,
+                    showProfile: navigate.showProfile
                 }}
             />
         </div>

--- a/src/feature/Profile/components/ProfileSelctView.tsx
+++ b/src/feature/Profile/components/ProfileSelctView.tsx
@@ -28,8 +28,11 @@ export default function ProfileSelectView(props: FormatProps<DBProfiles>) {
                     displayInteraction: true,
                 }}
                 eventHandler={{
-                    ...navigate,
-                    handleFollow
+                    handleFollow,
+                    showFollowers: navigate.showFollowers,
+                    showFollowings: navigate.showFollowings,
+                    showInteraction: navigate.showInteraction,
+                    showMutualFollowers: navigate.showMutualFollowers,
                 }}
             />
         </div>

--- a/src/feature/Profile/components/common/ProfileCoverImage.tsx
+++ b/src/feature/Profile/components/common/ProfileCoverImage.tsx
@@ -25,8 +25,8 @@ export default function ProfileCoverImage(props: ProfileCoverImageProps) {
             onClick={handleClickProfile}
             className={[
                 "profile-cover-image-component",
-                (miniView ? 'profile-cover-image-component__mini-view' : ''),
-                (handleShowProfile ? 'profile-cover-image-component__pointer' : ''),
+                (miniView ? 'profile-cover-image-component--mini-view' : ''),
+                (handleShowProfile ? 'profile-cover-image-component--pointer' : ''),
             ].join(' ')}
         >
             <BucketImage

--- a/src/feature/Profile/components/common/ProfileInteraction.tsx
+++ b/src/feature/Profile/components/common/ProfileInteraction.tsx
@@ -49,7 +49,10 @@ export default function ProfileInteraction(props: ProfileInteractionsProps ) {
                     {displayMoreInteraction &&
                         <div 
                             onClick={(e) => handleClickMoreInteraction(e)}
-                            className="profile-interaction-component__more-interaction"
+                            className={[
+                                "profile-interaction-component__more-interaction",
+                                handleShowInteraction ? "profile-interaction-component__more-interaction--pointer" : ""
+                            ].join(" ")}
                         >
                             <MoreIcon />
                         </div>

--- a/src/feature/Profile/components/common/ProfileUserInfo.tsx
+++ b/src/feature/Profile/components/common/ProfileUserInfo.tsx
@@ -2,7 +2,7 @@
 import type { MouseEvent } from 'react';
 import type { DBProfiles } from "$feature/Profile/types"
 /* styles */
-import "./style/profileInfo.scss"
+import "./style/profileUserInfo.scss"
 
 type ProfileUserInfoProps = {
     mutable_id: DBProfiles["mutable_id"]
@@ -20,14 +20,17 @@ export default function ProfileUserInfo(props: ProfileUserInfoProps) {
 
     return (
         <div 
-            className="profile-info-component"
+            className={[
+                "profile-user-info-component",
+                handleShowProfile ? "profile-user-info-component--pointer" : ""
+            ].join(" ")}
             onClick={(e) => handleClickProfile(e)}
         >
-            <span className="profile-info-component__mutable-id">
+            <span className="profile-user-info-component__mutable-id">
                 {mutable_id}
             </span>
             {miniView &&
-                <span className="profile-info-component__nickname">
+                <span className="profile-user-info-component__nickname">
                     {nickname}
                 </span>
             }

--- a/src/feature/Profile/components/common/style/profileCoverImage.scss
+++ b/src/feature/Profile/components/common/style/profileCoverImage.scss
@@ -4,11 +4,11 @@
     width: fit-content;
     border-radius: 50%;
 
-    &.profile-cover-image-component__pointer {
+    &.profile-cover-image-component--pointer {
         @include pointer;
     }
 
-    &.profile-cover-image-component__mini-view {
+    &.profile-cover-image-component--mini-view {
         width: 50%;
         height: 50%;
     }

--- a/src/feature/Profile/components/common/style/profileInteraction.scss
+++ b/src/feature/Profile/components/common/style/profileInteraction.scss
@@ -23,5 +23,9 @@
             width: var(--base-size);
             height: var(--base-size);
         }
+
+        &.profile-interaction-component__more-interaction--pointer {
+            @include pointer;
+        }
     }
 }

--- a/src/feature/Profile/components/common/style/profileUserInfo.scss
+++ b/src/feature/Profile/components/common/style/profileUserInfo.scss
@@ -1,16 +1,20 @@
 @import "src/lib/style/atomicMixin";
 
-.profile-info-component {
+.profile-user-info-component {
     @include flex-col;
     @include justify-center;
     font-size: calc(var(--base-size) * 1.5);
 
-    .profile-info-component__mutable-id {
+    &.profile-user-info-component--pointer {
+        @include pointer;
+    }
+
+    .profile-user-info-component__mutable-id {
         @include flex;
         @include align-center;
     }
 
-    .profile-info-component__nickname{
+    .profile-user-info-component__nickname{
         @include flex;
         @include align-center;
         color: rgba(var(--font-color), 0.5);

--- a/src/feature/Profile/hooks/useProfileNavigate.ts
+++ b/src/feature/Profile/hooks/useProfileNavigate.ts
@@ -1,8 +1,7 @@
 import { useNavigate } from "@tanstack/react-router"
 import { useCallback } from "react"
 
-type Handler = () => void
-export function useProfileNavigate(mutableId: string): Record<string, Handler> {
+export function useProfileNavigate(mutableId: string) {
     const navigate = useNavigate()
 
     const showProfileHandler = useCallback(() => {


### PR DESCRIPTION
#### 1. 미니 프로필, 프로필 셀렉트 뷰 컴포넌트 이벤트 핸들러 조정
- #39
- 수정된 오류
  - 메인 프로필 페이지에서 커버 이미지, 아이디를 누를 경우 다시 프로필 페이지로 이동함
#### 2. 사소한 수정
- CSS 클래스 수정 및 추가(커서 설정 등)
- 프로필 네비게이트 훅 불필요 타입 삭제