### PR TITLE
feat: 스크롤 복구 기능 추가 및 모달 스크롤 초기화 hooks추가

### DIFF
--- a/src/feature/portal/components/Modal.tsx
+++ b/src/feature/portal/components/Modal.tsx
@@ -1,41 +1,44 @@
-import type { MouseEventHandler, PropsWithChildren } from "react";
-import { useMemo } from 'react';
+import type { PropsWithChildren } from "react";
+import { useMemo, useRef } from 'react';
+import { useResetScroll } from "../hooks";
 import { createPortal } from "react-dom";
 import CloseIcon from "$lib/components/icons/CloseIcon";
 import './style/modal.scss'
 
 interface ModalProps extends PropsWithChildren {
     title: string
-    handleClickClose: () => void
+    handleClickClose?: () => void
 }
 
 export default function Modal(props: ModalProps) {
     const { title, children, handleClickClose } = props
-    const stopPropagation: MouseEventHandler<HTMLDivElement> = (e) => e.stopPropagation()
+    const ref = useRef<HTMLDivElement | null>(null)
     const rootElem = useMemo(() => document.getElementById('portal-root'), [])
+    useResetScroll(ref)
 
     return (
         <>
             {rootElem && createPortal(
-                <div className="modal-container" onClick={handleClickClose}>
-                    <div className="modal-main-container" onClick={stopPropagation} >
+                <div className="modal-component" onClick={handleClickClose}>
+                    <div className="modal-component__main-container" onClick={(e) => e.stopPropagation()} >
                         
-                        <div className="title-container">
-                            <div className="title-center-placeholder">{}</div>
-                            <div className="modal-title">{title}</div>
-                            <div className="title-center-placeholder">
-                                <button className="close-button" onClick={handleClickClose}>
-                                    <CloseIcon />
-                                </button>
+                        <div className="modal-component__title-container">
+                            <div className="modal-component__title-placeholder">{}</div>
+                            <div className="modal-component__title">{title}</div>
+                            <div className="modal-component__title-placeholder">
+                                {handleClickClose &&
+                                    <button className="modal-component__close-button" onClick={handleClickClose}>
+                                        <CloseIcon />
+                                    </button>
+                                }
                             </div>
                         </div>
 
-                        <div className="body-container">
-                            <div className="body-inner-container">
+                        <div ref={ref} className="modal-component__body-container">
+                            <div className="modal-component__body-inner-container">
                                 {children}
                             </div>
                         </div>
-                        
                     </div>
                 </div>,
             rootElem)}

--- a/src/feature/portal/components/style/modal.scss
+++ b/src/feature/portal/components/style/modal.scss
@@ -1,7 +1,7 @@
 @import "src/lib/style/mixin";
 @import "src/lib/style/atomicMixin";
 
-.modal-container {
+.modal-component {
     @include flex;
     @include flex-center;
     width: 100vw;
@@ -11,7 +11,7 @@
     top: 0;
     background-color: rgba(var(--modal-backdrop), 0.8);
 
-    .modal-main-container {
+    .modal-component__main-container {
         @include rounded-lg;
         @include flex;
         @include flex-col;
@@ -20,29 +20,25 @@
         height: 400px;
         background-color: rgba(var(--modal-background), 1);
         
-        .title-container {
+        .modal-component__title-container {
             @include flex;
             @include flex-center;
+            @include padding-(calc(var(--base-size) * 0.5));
             width: 100%;
-
-            font-size: 1rem;
             font-weight: bold;
-            padding-top: 0.5rem;
-            padding-bottom: 0.5rem;
-
-            .title-center-placeholder {
+            .modal-component__title-placeholder {
                 @include flex;
                 @include flex-center;
                 width: 15%;
             }
 
-            .modal-title {
+            .modal-component__title {
                 @include flex;
                 @include flex-center;
                 width: 70%;
             }
 
-            .close-button {
+            .modal-component__close-button {
                 @include flex;
                 @include flex-center;
 
@@ -52,21 +48,22 @@
             }
         }
         
-        .body-container {
+        .modal-component__body-container {
             @include custom-scroll;
+            @include w-full;
+            @include h-full;
             flex-grow: 1;
-            width: 100%;
-            height: 100%;
             border-top: rgba(var(--true-gray), 0.5) 0.25px solid;
             
-            .body-inner-container {
-                display: flex;
-                padding-top: 1rem;
-                padding-bottom: 1rem;
-                padding-left: 1.5rem;
-                padding-right: 1.5rem;
+            .modal-component__body-inner-container {
+                @include flex;
+                @include padding-(calc(var(--base-size) * 1.5));
             }
         }
-    }
-    
+    }   
+}
+
+// TODO DEBUG 스크롤이 있는 경우, 스크롤이 사라지면서 뷰포트 너비가 바뀜
+body:has(.modal-component) {
+    overflow:hidden;
 }

--- a/src/feature/portal/hooks/index.ts
+++ b/src/feature/portal/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useResetScroll'

--- a/src/feature/portal/hooks/useResetScroll.ts
+++ b/src/feature/portal/hooks/useResetScroll.ts
@@ -1,0 +1,15 @@
+import { MutableRefObject, useEffect } from "react"
+
+// COMMENT Tanstack Router의 Scroll이 modal 내부의 scroll도 복원되는 부분 제거
+export function useResetScroll(ref: MutableRefObject<HTMLDivElement | null>) {
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            if (!ref.current) return
+            ref.current.scrollTop = 0
+        }, 25)
+
+        return () => {
+            clearTimeout(timer)
+        }
+    }, [ref])
+}

--- a/src/lib/utils/route/getScrollKey.ts
+++ b/src/lib/utils/route/getScrollKey.ts
@@ -1,0 +1,18 @@
+import { ParsedLocation } from "@tanstack/react-router"
+
+// TODO - home, Oeuvre, author, category
+// TODO - 앱 규모가 커질 경우 리팩토링 필요
+// TODO 피드 가상화 시 스크롤- tanstack router 공식 문서
+export function getScrollKey(location: ParsedLocation) {
+    const { pathname } = location
+    const splittedPath = pathname.split("/")
+
+    if (
+        (splittedPath[1] === 'pentagram' || splittedPath[1] === 'profile') 
+        && (splittedPath[3] === 'view' || splittedPath[3] === 'update')
+    ) {
+        return splittedPath.slice(0, 4).join("/")
+    }
+
+    return splittedPath.join("/")
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,10 +1,8 @@
-import { Outlet, rootRouteWithContext } from '@tanstack/react-router'
-import { TanStackRouterDevtools } from '@tanstack/router-devtools'
-
 import type { AppStore } from '$lib/stores/store'
 import type { ApolloClient, NormalizedCacheObject } from '@apollo/client'
-
+import { Outlet, rootRouteWithContext, ScrollRestoration } from '@tanstack/react-router'
 import { checkSessionUser, checkTableUser } from '$feature/auth/function'
+import { getScrollKey } from '$lib/utils/route/getScrollKey'
 
 import Layout from '$lib/layout/Layout'
 import LeftSideBar from '$lib/components/NavigationBar/LeftSideBar'
@@ -24,8 +22,10 @@ export const Route = rootRouteWithContext<{
 function RootComponent() {
     return (
         <Layout left={<LeftSideBar />} >
+            <ScrollRestoration 
+                getKey={(location) => getScrollKey(location)}
+            />
             <Outlet />
-            <TanStackRouterDevtools />
         </Layout>
   )
 }


### PR DESCRIPTION
#### 1. 라우트 key 유틸 함수
- 현재 모달은 `쿼리 매개변수`나 `라우트 마스킹` 등의 `상태`로 관리되지 않음
- 실제로는 (라우터가 인식하는) 다른 주소로 이동하는 개념
- 따라서 라우터는
    - 모달이 열린 화면과 닫힌 화면은 다른 주소이므로 다른 `scroll`을 기억함
    - 이에 따라 같은 상위 페이지를 공유하는 경우 `scroll key`를 별도 조작

#### 2. 모달 내부 `scroll` 초기화 `hooks`
- 모달 내부의 `scroll`도 함께 기억되는 문제가 존재함
- 이에 따라 모달은 호출될 때 `scroll`을 0으로 만드는 `hooks`를 호출하도록 함

#### 3. 해결되지 않은 문제
- [x] `overflow y`를 통한 스크롤 방지의 문제 (unresolved)
    - 현재는 `body:has(.modal-component)`를 통해 스크롤을 방지
    - 이 경우 스크롤 방지를 위해 스크롤 바가 없어지면서 화면 내 요소들의 위치가 변경됨
    - 기능 상으로는 다른 문제가 발견되지 않음