### PR TITLE
fix: 펜타그램 수정 페이지 내 임시작성 본문 무조건적 초기화 오류 수정

### DIFF
--- a/src/feature/Pentagram/hooks/dataProcess/useInitialize.ts
+++ b/src/feature/Pentagram/hooks/dataProcess/useInitialize.ts
@@ -1,7 +1,7 @@
 import type { DBPentagram_UPDATE } from "../../types"
 import { useEffect } from "react"
 import { useDispatch } from "react-redux"
-import { initialize, setDescription } from "../../store/pentagramUpsertSlice"
+import { initialize } from "../../store/pentagramUpsertSlice"
 
 export function useInitialize(pentagram: DBPentagram_UPDATE | null) {
     const dispatch = useDispatch()
@@ -10,10 +10,5 @@ export function useInitialize(pentagram: DBPentagram_UPDATE | null) {
         dispatch(
             initialize( { nodes: pentagram?.pentagram_nodesCollection } )
         )
-        if (pentagram?.description) {
-            dispatch(
-                setDescription(pentagram?.description)
-            )
-        }
     }, [pentagram, dispatch])
 }


### PR DESCRIPTION
#### 1. 스토어 초기화 로직 수정
- 기존엔 수정 시, 저장된 본문 내용과 무관하게 `DB`의 본문으로 초기화
- 기존에 작성된 본문이 존재할 경우, 노드 수정 여부와 무관하게 확인 후 초기화 