### PR TITLE
fix: 펜타그램 임시 저장 로직 문제 수정

### DIFF
--- a/src/feature/Pentagram/components/PentagramUpsertView/PentagramUpsertEditor/PentagramDescription/index.tsx
+++ b/src/feature/Pentagram/components/PentagramUpsertView/PentagramUpsertEditor/PentagramDescription/index.tsx
@@ -2,7 +2,7 @@ import type { ChangeEvent } from "react"
 import './style/pentagramDescription.scss'
 
 type PentagramDescriptionProps = {
-    description: string,
+    description: string | null,
     handleSetDescription: (e: ChangeEvent<HTMLTextAreaElement>) => void,
 }
 
@@ -18,7 +18,7 @@ export default function PentagramDescription(props : PentagramDescriptionProps) 
         <div className="pentagram-description-component">
             <textarea
                 className="pentagram-description-component__text-area"
-                value={description}
+                value={description || ""}
                 onChange={onChange}
             />
         </div>

--- a/src/feature/Pentagram/components/PentagramUpsertView/PentagramUpsertEditor/index.tsx
+++ b/src/feature/Pentagram/components/PentagramUpsertView/PentagramUpsertEditor/index.tsx
@@ -16,7 +16,7 @@ export type PentagramUpsertEditorProps = {
 
     angle: number | null,
     distance: number | null ,
-    description: string,
+    description: string | null,
     
     // COMMENT 이벤트 핸들러가 렌더링 중 바뀔 여지가 많고, object로 묶을 경우 전체 리렌더링 유발로 인해 나누어 전달
     handleClickNode?: (nodeId: string) => void,

--- a/src/feature/Pentagram/store/pentagramUpsertSlice/index.ts
+++ b/src/feature/Pentagram/store/pentagramUpsertSlice/index.ts
@@ -33,7 +33,7 @@ const pentagramUpsertSlice = createSlice({
     name: 'pentagramUpsert',
     initialState: {
         pentagramId: null as NullableString,
-        description: "",
+        description: null as NullableString,
         mergedNode: mergedNodeAdapter.getInitialState(),
         node: nodeAdapter.getInitialState(),
         pendingChange: pendingChangeAdapter.getInitialState(),
@@ -47,11 +47,11 @@ const pentagramUpsertSlice = createSlice({
             initializeNode(state, action)
         },
 
-        setPentagramId(state, action: PayloadAction<string>) {
+        setPentagramId(state, action: PayloadAction<NullableString>) {
             state.pentagramId = action.payload
         },
 
-        setDescription(state, action: PayloadAction<string>) {
+        setDescription(state, action: PayloadAction<NullableString>) {
             state.description = action.payload
         },
 
@@ -175,7 +175,7 @@ const pentagramUpsertSlice = createSlice({
 
         abortChanges(state) {
             state.pendingChange = pendingChangeAdapter.getInitialState()
-            state.description = ''
+            state.description = null
         },
 
         unselectSelected(state) {


### PR DESCRIPTION
#### 1. 해결된 문제
- 기존 문제 사항
  - 빈 문자열이 저장된 경우, 저장사항이 있는 것으로 인식하지 않음
- 빈 문자열도 임시 저장 사항으로 취급하도록 변경