### PR TITLE
chore: 펜타그램 상호작용 모달 쿼리 추가(네트워크 요청 내 불필요 payload 최소화)

### DIFF
--- a/src/feature/Pentagram/graphql/fragments/pentagrams.ts
+++ b/src/feature/Pentagram/graphql/fragments/pentagrams.ts
@@ -44,3 +44,12 @@ graphql(/* GraphQL */ `
         }
     }
 `)
+
+graphql(/* GraphQL */ `
+    fragment PentagramsSelectUserInfo on pentagrams {
+        id
+        users {
+            ...MiniProfile
+        }
+    }
+`)

--- a/src/feature/Pentagram/graphql/query.ts
+++ b/src/feature/Pentagram/graphql/query.ts
@@ -28,6 +28,20 @@ export const getPentagramSelectInfoById_QUERY = graphql(/* GraphQL */ `
     }
 `)
 
+export const getPentagramsSelectUserInfoById_QUERY = graphql(/* GraphQL */ `
+    query getPentagramsSelectUserInfoById($id: UUID!) {
+        pentagramsCollection(
+            filter: { id: { eq: $id } }
+        ) {
+            edges {
+                node {
+                    ...PentagramsSelectUserInfo
+                }
+            }
+        }
+    }
+`)
+
 export const getPentagramNodesInfoById_QUERY = graphql(/* GraphQL */ `
     query getPentagramNodesInfoById($id: UUID!) {
         pentagram_nodesCollection(


### PR DESCRIPTION
#### 1. 펜타그램 상호작용 모달 전용 쿼리 추가
- #52
- 상호작용 모달을 위해 불필요하게 긴 `네트워크 응답`이 필요하지 않음
- 일반적인 상황에서는 `캐시`가 작동
- `네트워크 재연결` 등의 상황에서 불필요한 네트워크 응답 발생
- 이러한 상황을 최소화하기 위해 별도 쿼리 생성
- `Modal` 컴포넌트(#52)에서 구현 예정된 것을 구현한 내용