### PR TITLE
chore: 기존 변경 사항(#47, #51, #52) 누락 사항 추가 및 반영

### DIFF
--- a/src/feature/Pentagram/components/PentagramUpsertView/PentagramUpsertEditor/PendingChangeList/index.tsx
+++ b/src/feature/Pentagram/components/PentagramUpsertView/PentagramUpsertEditor/PendingChangeList/index.tsx
@@ -16,7 +16,6 @@ export default function PendingChangeList(props: PendingChangeProps) {
             {unmergedNodeInfos.map((item) => 
                 <PendingChanges 
                     key={item.id}
-                    id={item.id}
                     item={item}
                     handleClickRevert={handleClickRevert}
                 />

--- a/src/feature/Pentagram/components/PentagramUpsertView/PentagramUpsertEditor/UpdateMainPentagon/index.tsx
+++ b/src/feature/Pentagram/components/PentagramUpsertView/PentagramUpsertEditor/UpdateMainPentagon/index.tsx
@@ -44,7 +44,6 @@ export default forwardRef(function UpdateMainPentagon(props: UpdateMainPentagonP
                     mergedNodes.map((item) => (
                         <MergedNode 
                             key={item.id}
-                            id={item.id}
                             item={item}
                             handleDragAndTouchMove={handleDragAndTouchMove}
                             handleClickSelectedNode={handleClickSelectedNode}

--- a/src/feature/Pentagram/constants.ts
+++ b/src/feature/Pentagram/constants.ts
@@ -9,3 +9,7 @@ export const PENTAGRAM = {
     VERTEX_ANGLE_THRESHOLD: 5,
     VERTEX_DISTANCE_THRESHOLD: 10,
 }
+
+export const TIME = {
+    NOW_OFFSET: 3000
+}

--- a/src/feature/Pentagram/hooks/eventHandler/update/useSetPentagramDescription.ts
+++ b/src/feature/Pentagram/hooks/eventHandler/update/useSetPentagramDescription.ts
@@ -1,14 +1,12 @@
-import type { AppRootState } from "$lib/stores/store"
 import type { ChangeEvent } from "react"
-import { useDispatch, useSelector } from "react-redux"
+import { useDispatch } from "react-redux"
 import { setDescription } from "$feature/Pentagram/store/pentagramUpsertSlice"
 
-export function useSetPentagramDescription(): [typeof description, typeof handleSetDescription] {    
+export function useSetPentagramDescription() {    
     const dispatch = useDispatch()
-    const description = useSelector((state: AppRootState) => state.pentagramUpsert.description)
     const handleSetDescription = (e: ChangeEvent<HTMLTextAreaElement>) => {
         dispatch(setDescription(e.target.value))
     }
 
-    return [description, handleSetDescription]
+    return { handleSetDescription }
 }

--- a/src/feature/Pentagram/hooks/selector/index.ts
+++ b/src/feature/Pentagram/hooks/selector/index.ts
@@ -1,3 +1,4 @@
+export * from './useDescription'
 export * from './useMergedNode'
 export * from './useUnmergedChangeInfo'
 export * from './useSelectedPosition'

--- a/src/feature/Pentagram/hooks/selector/useDescription.ts
+++ b/src/feature/Pentagram/hooks/selector/useDescription.ts
@@ -1,0 +1,7 @@
+import type { AppRootState } from "$lib/stores/store";
+import { useSelector } from "react-redux";
+
+export function useDescription() {
+    const description = useSelector((state: AppRootState) => state.pentagramUpsert.description)
+    return description
+}

--- a/src/feature/Pentagram/utils/components/getSnapshot.ts
+++ b/src/feature/Pentagram/utils/components/getSnapshot.ts
@@ -6,25 +6,25 @@ export function getSnapshot(
     timestamp: Date
 ) {
     const position = unionedChanges.find((change) => {
-        if (!change?.item) return false
-        if (!change.item?.created_at) return false
-        if (new Date(change.item?.created_at) > timestamp) return false
-        if (typeof change.item?.current_angle !== 'number') return false
-        if (typeof change.item?.current_distance !== 'number') return false
+        if (!change) return false
+        if (!change?.created_at) return false
+        if (new Date(change?.created_at) > timestamp) return false
+        if (typeof change?.current_angle !== 'number') return false
+        if (typeof change?.current_distance !== 'number') return false
         return true
     })
 
     const deleted = unionedChanges
         .find((change) => {
-            if (!change?.item) return false
-            if (!change.item?.created_at) return false
-            if (new Date(change.item?.created_at) > timestamp) return false
+            if (!change) return false
+            if (!change?.created_at) return false
+            if (new Date(change?.created_at) > timestamp) return false
             return true
         })
-        ?.item.changeType === 'remove'
+        ?.changeType === 'remove'
 
-    const angle = position ? position.item.current_angle : null;
-    const distance = position ? position.item.current_distance : null;
+    const angle = position ? position.current_angle : null;
+    const distance = position ? position.current_distance : null;
 
     return { angle, distance, deleted }
 }

--- a/src/feature/Pentagram/utils/components/getUnionedChanges.ts
+++ b/src/feature/Pentagram/utils/components/getUnionedChanges.ts
@@ -1,7 +1,6 @@
 import type { RecoverRecordInfoFragment, RemoveRecordInfoFragment, UpdateRecordInfoFragment, UpsertRecordInfoFragment } from "$lib/graphql/__generated__/graphql";
-import type { ChangeTypeKey, PentagramChangeProps } from "../../components/common/PentagramChange";
+import type { ChangeTypeKey, TPentagramChange } from "../../components/common/PentagramChange";
 import type { Collections } from "$lib/types/graphql";
-import { formatProps } from "$lib/utils";
 
 type EntityWithUnunionedChanges= {
     pentagram_revision_upsert_recordsCollection?: Collections<UpsertRecordInfoFragment> | null | undefined,
@@ -10,7 +9,7 @@ type EntityWithUnunionedChanges= {
     pentagram_revision_recover_recordsCollection?: Collections<RecoverRecordInfoFragment> | null | undefined
 } | null | undefined
 
-export function getUnionedChanges(node: EntityWithUnunionedChanges):PentagramChangeProps[] {
+export function getUnionedChanges(node: EntityWithUnunionedChanges):TPentagramChange[] {
     if (!node) return []
 
     const { 
@@ -28,22 +27,22 @@ export function getUnionedChanges(node: EntityWithUnunionedChanges):PentagramCha
     }
 
     const keys:ChangeTypeKey[] = ["upsert", "update", "remove", "recover"]
-    const result: PentagramChangeProps[] = keys
+    const result: TPentagramChange[] = keys
         .map((key) => (
-            unprocessedChanges[key]?.edges?.map((edge) => formatProps({
+            unprocessedChanges[key]?.edges?.map((edge) => ({
                 ...edge.node,
                 created_at: edge.node.pentagram_revisions.created_at,
                 oeuvres: edge.node.pentagram_nodes.oeuvres,
                 changeType: key
             }))
         ))
-        .reduce((acc: PentagramChangeProps[], cur) => {
+        .reduce((acc: TPentagramChange[], cur) => {
             if (!cur) return acc
             return acc?.concat(cur)
         }, [])
         .sort((a, b) => {
-            if (!a.item?.created_at || !b.item?.created_at) return 0
-            return new Date(b.item?.created_at).getTime() - new Date(a.item?.created_at).getTime()
+            if (!a?.created_at || !b?.created_at) return 0
+            return new Date(b?.created_at).getTime() - new Date(a?.created_at).getTime()
         })
 
     return result

--- a/src/feature/Profile/components/MiniProfile.tsx
+++ b/src/feature/Profile/components/MiniProfile.tsx
@@ -1,7 +1,8 @@
 import type { RouterContext } from '$lib/types/components';
 import type { DBMiniProfile } from "$feature/Profile/types";
 
-import { useHandleFollow, useProfileNavigate } from '../hooks';
+import { useHandleFollow } from '../hooks';
+import { useProfileNavigate } from '$feature/navigate/hooks';
 import UserInfoCard from './UserInfoCard';
 
 import "./style/miniProfile.scss"
@@ -14,7 +15,7 @@ type MiniProfileProps = {
 
 export default function MiniProfile(props: MiniProfileProps) {
     const { item, context, displayFollow } = props
-    const navigate = useProfileNavigate(item.mutable_id)
+    const navigate = useProfileNavigate()
     const handleFollow = useHandleFollow(item.id, context.currentUser)
 
     return (
@@ -35,7 +36,7 @@ export default function MiniProfile(props: MiniProfileProps) {
                 }}
                 eventHandler={{
                     handleFollow,
-                    showProfile: navigate.showProfile
+                    showProfile: navigate.profileSelect
                 }}
                 context={context}
             />

--- a/src/feature/Profile/components/ProfileSelctView.tsx
+++ b/src/feature/Profile/components/ProfileSelctView.tsx
@@ -1,7 +1,8 @@
 import type { RouterContext } from '$lib/types/components';
 import type { DBProfiles } from "$feature/Profile/types";
 
-import { useHandleFollow, useProfileNavigate } from '../hooks';
+import { useHandleFollow } from '../hooks';
+import { useProfileNavigate } from '$feature/navigate/hooks';
 import UserInfoCard from './UserInfoCard';
 
 import "./style/profileSelectView.scss"
@@ -11,7 +12,7 @@ export default function ProfileSelectView(props: {
     context: RouterContext
 }) {
     const { item, context } = props
-    const navigate = useProfileNavigate(item.mutable_id)
+    const navigate = useProfileNavigate()
     const handleFollow = useHandleFollow(item.id, context.currentUser)
 
     return (
@@ -32,10 +33,10 @@ export default function ProfileSelectView(props: {
                 }}
                 eventHandler={{
                     handleFollow,
-                    showFollowers: navigate.showFollowers,
-                    showFollowings: navigate.showFollowings,
-                    showInteraction: navigate.showInteraction,
-                    showMutualFollowers: navigate.showMutualFollowers,
+                    showFollowers: navigate.followersDetail,
+                    showFollowings: navigate.followingsDetail,
+                    showInteraction: navigate.profileSelectDetail,
+                    showMutualFollowers: navigate.mutualFollowersDetail,
                 }}
                 context={context}
             />

--- a/src/feature/Profile/components/UserInfoCard/index.tsx
+++ b/src/feature/Profile/components/UserInfoCard/index.tsx
@@ -15,11 +15,11 @@ import './style/index.scss'
 type UserInfoCardKeys = "coverImage" | "title" | "mainInfo" | "subInfo"
 type UserInfoCardOptionKey = "full" | "miniView" | "displayFollow" | "displayInteraction"
 type UserInfoCardEventHandler = {
-    showProfile?: () => void
-    showMutualFollowers?: () => void
-    showFollowings?: () => void
-    showFollowers?: () => void
-    showInteraction?: () => void
+    showProfile?: (mutableId: string) => void
+    showMutualFollowers?: (mutableId: string) => void
+    showFollowings?: (mutableId: string) => void
+    showFollowers?: (mutableId: string) => void
+    showInteraction?: (mutableId: string) => void
     
     handleFollow?: () => void
 }
@@ -50,6 +50,7 @@ export default function UserInfoCard(props: UserInfoCardProps) {
         ].join(" ")}>
             <ProfileCoverImage 
                 id={id} 
+                mutable_id={mutable_id}
                 miniView={false}
                 handleShowProfile={eventHandler.showProfile}
             />
@@ -66,6 +67,7 @@ export default function UserInfoCard(props: UserInfoCardProps) {
             ].join(" ")}>
                 <ProfileCoverImage 
                     id={id} 
+                    mutable_id={mutable_id}
                     miniView={false}
                     handleShowProfile={eventHandler.showProfile}
                 />
@@ -83,6 +85,7 @@ export default function UserInfoCard(props: UserInfoCardProps) {
                     handleShowProfile={eventHandler.showProfile}
                 />
                 <ProfileInteraction 
+                    mutable_id={mutable_id}
                     isMe={isMe}
                     followed={followed}
                     displayFollow={options.displayFollow}
@@ -96,6 +99,7 @@ export default function UserInfoCard(props: UserInfoCardProps) {
 
     const mainInfo = (
         <ProfileFollowingInfo
+            mutable_id={mutable_id}
             followersCollection={followersCollection}
             followingsCollection={followingsCollection}
             handleShowFollowings={eventHandler.showFollowings}
@@ -105,6 +109,7 @@ export default function UserInfoCard(props: UserInfoCardProps) {
 
     const subInfo = (
         <ProfileDescriptionInfo
+            mutable_id={mutable_id}
             nickname={nickname}
             description={description}
             mutualFollowers={mutualFollowers}

--- a/src/feature/Profile/components/UserInfoCard/style/index.scss
+++ b/src/feature/Profile/components/UserInfoCard/style/index.scss
@@ -1,8 +1,13 @@
+@use "src/lib/style/variables";
 @import "src/lib/style/atomicMixin";
 
 .user-info-card-component {
     @include flex;
     @include child-left-m(calc(var(--base-size) * 0.5));
+    --node: #{variables.$node_small}px;
+    @media only screen and (min-width: 500px) {
+        --node: #{variables.$node_medium}px;
+    }
 
     .user-info-card-component__title-container {
         @include flex;
@@ -11,10 +16,10 @@
         .user-info-card-component__cover-image-container {
             margin-right: calc(var(--base-size) * 1.25);
             &.user-info-card-component__cover-image-container--mini-view {
-                min-width: 36px;
-                max-width: 36px;
-                min-height: 36px;
-                max-height: 36px;
+                min-width: var(--node);
+                max-width: var(--node);
+                min-height: var(--node);
+                max-height: var(--node);
             }
     
             &.user-info-card-component__cover-image-container--mobile { 

--- a/src/feature/Profile/components/common/ProfileCoverImage.tsx
+++ b/src/feature/Profile/components/common/ProfileCoverImage.tsx
@@ -9,16 +9,17 @@ import "./style/profileCoverImage.scss"
 
 type ProfileCoverImageProps = {
     id: DBProfiles["id"]
+    mutable_id: DBProfiles["mutable_id"]
     miniView?: boolean
-    handleShowProfile?: () => void
+    handleShowProfile?: (mutableId: string) => void
 }
 
 export default function ProfileCoverImage(props: ProfileCoverImageProps) {
-    const { id, miniView, handleShowProfile } = props
+    const { id, mutable_id, miniView, handleShowProfile } = props
     
     const onClickProfile = (e: MouseEvent) => {
         e.stopPropagation()
-        if (handleShowProfile) handleShowProfile()
+        if (handleShowProfile) handleShowProfile(mutable_id)
     }
 
     return (

--- a/src/feature/Profile/components/common/ProfileDescriptionInfo.tsx
+++ b/src/feature/Profile/components/common/ProfileDescriptionInfo.tsx
@@ -9,15 +9,16 @@ import PROFILE from "$feature/Profile/constants"
 import "./style/profileDescriptionInfo.scss"
 
 type ProfileDescriptionInfoProps = {
+    mutable_id: DBProfiles["mutable_id"]
     nickname: DBProfiles["nickname"], 
     description: DBProfiles["description"]
     mutualFollowers: ReturnType<typeof calcMutualFollowers>
 
-    handleShowMutualFollowers?: () => void
+    handleShowMutualFollowers?: (mutableId: string) => void
 }
 
 export default function ProfileDescriptionInfo(props: ProfileDescriptionInfoProps) {
-    const { nickname, mutualFollowers, description, handleShowMutualFollowers } = props
+    const { mutable_id, nickname, mutualFollowers, description, handleShowMutualFollowers } = props
     
     const mutualFollowerDisplayCount = PROFILE.DEFAULT_VALUES.mutualFollowerDisplayCount
     const totalMutualFollowerCount = mutualFollowers.length
@@ -28,7 +29,7 @@ export default function ProfileDescriptionInfo(props: ProfileDescriptionInfoProp
 
     const onClickMutualFollowing = (e: MouseEvent) => {
         e.stopPropagation()
-        if (handleShowMutualFollowers) handleShowMutualFollowers()
+        if (handleShowMutualFollowers) handleShowMutualFollowers(mutable_id)
     }
 
     return (

--- a/src/feature/Profile/components/common/ProfileFollowingInfo.tsx
+++ b/src/feature/Profile/components/common/ProfileFollowingInfo.tsx
@@ -9,23 +9,24 @@ import { calcCollectionLength } from "$lib/utils/graphql"
 import "./style/profileFollowingInfo.scss"
 
 type ProfileFollowingInfoProps = {
+    mutable_id: DBProfiles["mutable_id"]
     followingsCollection: DBProfiles["followingsCollection"]
     followersCollection: DBProfiles["followersCollection"]
 
-    handleShowFollowings?: () => void
-    handleShowFollowers?: () => void
+    handleShowFollowings?: (mutableId: string) => void
+    handleShowFollowers?: (mutableId: string) => void
 }
 
 export default function ProfileFollowingInfo(props: ProfileFollowingInfoProps) {
-    const { followingsCollection, followersCollection, handleShowFollowings, handleShowFollowers } = props
+    const { mutable_id, followingsCollection, followersCollection, handleShowFollowings, handleShowFollowers } = props
     const { t } = useTranslation()
 
     const onClickCountButton = (
         e: MouseEvent, 
-        func: (() => void)| undefined
+        func: ((mutableId: string) => void)| undefined
     ) => {
         e.stopPropagation()
-        if (func) func()
+        if (func) func(mutable_id)
     }
 
     return (

--- a/src/feature/Profile/components/common/ProfileInteraction.tsx
+++ b/src/feature/Profile/components/common/ProfileInteraction.tsx
@@ -1,4 +1,5 @@
 /* types */
+import type { DBProfiles } from '$feature/Profile/types';
 import type { MouseEvent } from 'react';
 /* hooks */
 import { useTranslation } from "react-i18next";
@@ -9,16 +10,17 @@ import MoreIcon from "$lib/components/icons/MoreIcon";
 import "./style/profileInteraction.scss"
 
 type ProfileInteractionsProps = {
+    mutable_id: DBProfiles["mutable_id"]
     isMe?: boolean | undefined,
     followed?: boolean | undefined,
     displayFollow?: boolean
     displayMoreInteraction?: boolean
     handleFollow?: () => void
-    handleShowInteraction?: () => void
+    handleShowInteraction?: (mutableId: string) => void
 }
 
 export default function ProfileInteraction(props: ProfileInteractionsProps ) {
-    const { isMe, followed, displayFollow, displayMoreInteraction, handleFollow, handleShowInteraction } = props
+    const { mutable_id, isMe, followed, displayFollow, displayMoreInteraction, handleFollow, handleShowInteraction } = props
     const { t } = useTranslation()
 
     const onClickFollow = (e:MouseEvent) => {
@@ -28,7 +30,7 @@ export default function ProfileInteraction(props: ProfileInteractionsProps ) {
 
     const onClickInteraction = (e: MouseEvent) => {
         e.stopPropagation()
-        if (handleShowInteraction) handleShowInteraction()
+        if (handleShowInteraction) handleShowInteraction(mutable_id)
     }
 
     return (

--- a/src/feature/Profile/components/common/ProfileUserInfo.tsx
+++ b/src/feature/Profile/components/common/ProfileUserInfo.tsx
@@ -8,7 +8,7 @@ type ProfileUserInfoProps = {
     mutable_id: DBProfiles["mutable_id"]
     nickname: DBProfiles["nickname"]
     miniView?: boolean,
-    handleShowProfile?: () => void
+    handleShowProfile?: (mutableId: string) => void
 }
 
 export default function ProfileUserInfo(props: ProfileUserInfoProps) {
@@ -16,7 +16,7 @@ export default function ProfileUserInfo(props: ProfileUserInfoProps) {
 
     const onClickProfile = (e: MouseEvent) => {
         e.stopPropagation()
-        if (handleShowProfile) handleShowProfile()
+        if (handleShowProfile) handleShowProfile(mutable_id)
     }
 
     return (

--- a/src/feature/Profile/components/modal/MiniProfileModal.tsx
+++ b/src/feature/Profile/components/modal/MiniProfileModal.tsx
@@ -21,7 +21,6 @@ export default function MiniProfileModal(props: MiniProfileModalProps) {
                 {items.map((item) => (
                     <MiniProfile 
                         key={item.id}
-                        id={item.id}
                         item={item}
                         context={context}
                         displayFollow={true}

--- a/src/feature/portal/components/Modal.tsx
+++ b/src/feature/portal/components/Modal.tsx
@@ -1,5 +1,5 @@
-import type { PropsWithChildren } from "react";
-import { useMemo, useRef } from 'react';
+import type { MouseEvent, PropsWithChildren } from "react";
+import { useRef } from 'react';
 import { useResetScroll } from "../hooks";
 import { createPortal } from "react-dom";
 import CloseIcon from "$lib/components/icons/CloseIcon";
@@ -13,21 +13,25 @@ interface ModalProps extends PropsWithChildren {
 export default function Modal(props: ModalProps) {
     const { title, children, handleClickClose } = props
     const ref = useRef<HTMLDivElement | null>(null)
-    const rootElem = useMemo(() => document.getElementById('portal-root'), [])
+    const rootElem = document.getElementById('portal-root')
     useResetScroll(ref)
+
+    const onClickClose = (e: MouseEvent) => {
+        e.stopPropagation()
+        if (handleClickClose) handleClickClose()
+    }
 
     return (
         <>
             {rootElem && createPortal(
-                <div className="modal-component" onClick={handleClickClose}>
+                <div className="modal-component" onClick={onClickClose}>
                     <div className="modal-component__main-container" onClick={(e) => e.stopPropagation()} >
-                        
                         <div className="modal-component__title-container">
                             <div className="modal-component__title-placeholder">{}</div>
                             <div className="modal-component__title">{title}</div>
                             <div className="modal-component__title-placeholder">
                                 {handleClickClose &&
-                                    <button className="modal-component__close-button" onClick={handleClickClose}>
+                                    <button className="modal-component__close-button" onClick={onClickClose}>
                                         <CloseIcon />
                                     </button>
                                 }

--- a/src/feature/portal/components/style/modal.scss
+++ b/src/feature/portal/components/style/modal.scss
@@ -63,7 +63,6 @@
     }   
 }
 
-// TODO DEBUG 스크롤이 있는 경우, 스크롤이 사라지면서 뷰포트 너비가 바뀜
 body:has(.modal-component) {
     overflow:hidden;
 }

--- a/src/feature/template/components/InfoCardTemplate.tsx
+++ b/src/feature/template/components/InfoCardTemplate.tsx
@@ -3,18 +3,18 @@ import type { MouseEventHandler } from "react"
 import { filterComponents } from "../util"
 import "./style/infoCard.scss"
 
-export type RenderConfigKey = "coverImage" | "title" | "mainInfo" | "subInfo"
+export type InfoCardRenderConfigKey = "coverImage" | "title" | "mainInfo" | "subInfo"
 
 type InfoCardProps = {
     id: string,
-    components: ISlotComponent<RenderConfigKey>,
-    renderConfig: ISlotRenderConfig<RenderConfigKey>,
+    components: ISlotComponent<InfoCardRenderConfigKey>,
+    renderConfig: ISlotRenderConfig<InfoCardRenderConfigKey>,
     onClick?: MouseEventHandler<HTMLDivElement>
 }
 
 export default function InfoCardTemplate (props: InfoCardProps) {
     const { components, renderConfig, ...restProps } = props
-    const filteredComponents = filterComponents<RenderConfigKey>(components, renderConfig)
+    const filteredComponents = filterComponents<InfoCardRenderConfigKey>(components, renderConfig)
 
     return (
         <div 

--- a/src/feature/template/type.ts
+++ b/src/feature/template/type.ts
@@ -1,3 +1,4 @@
 export type ISlotItem = React.JSX.Element | string | undefined | null
 export type ISlotComponent<K extends string> = Record<K, ISlotItem>
-export type ISlotRenderConfig<K extends string, V=boolean> = Record<K, V>
+export type ISlotRenderConfig<K extends string> = Record<K, boolean>
+export type ISlotOptions<K extends string, V extends (boolean | string)> = Record<K, V>

--- a/src/routes/_auth/pentagram/$pentagramId/update.tsx
+++ b/src/routes/_auth/pentagram/$pentagramId/update.tsx
@@ -4,6 +4,7 @@ import { Outlet, createFileRoute, redirect } from '@tanstack/react-router'
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useThrottledErrorToast } from '$lib/hooks';
+import { usePentagramNavigate } from "$feature/navigate/hooks"
 import { 
     useInitialize, 
     useMutationHandler,
@@ -11,7 +12,6 @@ import {
     useMerge, 
     useMergedNode, 
     usePendingChangeListEventHandler, 
-    usePentagramNavigate, 
     useQuadtreeRef, 
     useSelectedPosition, 
     useUnmergedChangeInfo, 
@@ -90,7 +90,7 @@ function PentagramUpdate() {
         errorToast(async () => {
             await handleUpdatePentagram(pentagramId)
             toast.success(t("pentagram.toast.success.updatePentagram"))
-            navigate.view(pentagramId)
+            navigate.viewPentagram(pentagramId)
         })
     }
 
@@ -116,7 +116,7 @@ function PentagramUpdate() {
                 
                 handleClickNode={handleSelectNode}
                 handleClickSelectedNode={(nodeId: string) => navigate.nodeUpsertDetail(nodeId, Route.fullPath ,params)}
-                handleClickSelectedPosition={() => navigate.nodeInsert(Route.fullPath ,params)}
+                handleClickSelectedPosition={() => navigate.nodeInsertDetail(Route.fullPath ,params)}
                 handleSetNewPosition={handleSetNewPosition}
                 handleDragAndTouchMove={handleDragAndTouchMove}
 

--- a/src/routes/_auth/pentagram/create.tsx
+++ b/src/routes/_auth/pentagram/create.tsx
@@ -2,13 +2,13 @@ import { Outlet, createFileRoute } from '@tanstack/react-router'
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useThrottledErrorToast } from '$lib/hooks';
+import { usePentagramNavigate } from "$feature/navigate/hooks"
 import { 
     useMutationHandler,
     useMainPentagonEventHandler, 
     useMerge, 
     useMergedNode, 
     usePendingChangeListEventHandler, 
-    usePentagramNavigate, 
     useQuadtreeRef, 
     useSelectedPosition, 
     useUnmergedChangeInfo, 
@@ -60,7 +60,7 @@ function PentagramInsert() {
         errorToast(async () => {
             const result = await handleInsertPentagram()
             toast.success(t("pentagram.toast.success.createPentagram"))
-            navigate.view(result)
+            navigate.viewPentagram(result)
         })
     }
 
@@ -86,7 +86,7 @@ function PentagramInsert() {
                 
                 handleClickNode={handleSelectNode}
                 handleClickSelectedNode={(nodeId: string) => navigate.nodeUpsertDetail(nodeId, Route.fullPath)}
-                handleClickSelectedPosition={() => navigate.nodeInsert(Route.fullPath)}
+                handleClickSelectedPosition={() => navigate.nodeInsertDetail(Route.fullPath)}
                 handleSetNewPosition={handleSetNewPosition}
                 handleDragAndTouchMove={handleDragAndTouchMove}
 

--- a/src/routes/_public/pentagram/$pentagramId/view.tsx
+++ b/src/routes/_public/pentagram/$pentagramId/view.tsx
@@ -2,7 +2,7 @@ import type { GetPentagramSelectInfoByIdQuery } from '$lib/graphql/__generated__
 import { Outlet, createFileRoute } from '@tanstack/react-router'
 
 import { useQuery } from '@apollo/client';
-import { usePentagramNavigate } from '$feature/Pentagram/hooks';
+import { usePentagramNavigate } from "$feature/navigate/hooks"
 
 import { getPentagramSelectInfoById_QUERY } from '$feature/Pentagram/graphql';
 import { getFirstNodeOfCollection } from '$lib/utils/graphql';
@@ -27,8 +27,8 @@ function PentagramSelect() {
 
     const eventHandler = {
         node: (nodeId: string) => navigate.nodeSelectDetail(nodeId, Route.fullPath, params),
-        interaction: (pentagramId: string) => navigate.selectInteraction(pentagramId, Route.fullPath, params),
-        revision: (revisionId: string) => navigate.revisionDetail(revisionId, Route.fullPath, params)
+        interaction: (pentagramId: string) => navigate.pentagramSelectDetail(pentagramId, Route.fullPath, params),
+        revision: (revisionId: string) => navigate.revisionSelectDetail(revisionId, Route.fullPath, params)
     }
 
     // TODO THROW ERROR + AUTH

--- a/src/routes/_public/pentagram/$pentagramId/view.tsx
+++ b/src/routes/_public/pentagram/$pentagramId/view.tsx
@@ -6,6 +6,7 @@ import { usePentagramNavigate } from "$feature/navigate/hooks"
 
 import { getPentagramSelectInfoById_QUERY } from '$feature/Pentagram/graphql';
 import { getFirstNodeOfCollection } from '$lib/utils/graphql';
+import { TIME } from '$feature/Pentagram/constants';
 
 import PentagramSelectView from '$feature/Pentagram/components/PentagramSelectView';
 
@@ -48,7 +49,7 @@ function PentagramSelect() {
                     horizontalMain: false,
                 }}
                 eventHandler={eventHandler}
-                timestamp={new Date()}
+                timestamp={new Date(Date.now() + TIME.NOW_OFFSET)}
                 context={context}
             />
             <Outlet />

--- a/src/routes/_public/profile/$mutableId/followers.tsx
+++ b/src/routes/_public/profile/$mutableId/followers.tsx
@@ -3,7 +3,7 @@ import type { DBMiniProfile } from '$feature/Profile/types';
 import type { GetProfileByMutableIdQuery } from '$lib/graphql/__generated__/graphql';
 /* hooks */
 import { useQuery } from '@apollo/client';
-import { useNavigate } from "@tanstack/react-router"
+import { useProfileNavigate } from '$feature/navigate/hooks';
 import { useTranslation } from 'react-i18next';
 /* query */
 import { getProfileByMutableId_QUERY } from '$feature/Profile/graphql';
@@ -37,12 +37,12 @@ function FollowersModalComponent(props: {
 }) {
     const params = Route.useParams()
     const context = Route.useRouteContext()
-    const navigate = useNavigate()
+    const navigate = useProfileNavigate()
     const { t } = useTranslation()
 
     const title = t("modal.title.followers")
     const handleClickClose = () => {
-        navigate({to: "/profile/$mutableId", params: params})
+        navigate.profileSelect(params.mutableId)
     }
 
     return (

--- a/src/routes/_public/profile/$mutableId/followings.tsx
+++ b/src/routes/_public/profile/$mutableId/followings.tsx
@@ -3,7 +3,7 @@ import type { DBMiniProfile } from '$feature/Profile/types';
 import type { GetProfileByMutableIdQuery } from '$lib/graphql/__generated__/graphql';
 /* hooks */
 import { useQuery } from '@apollo/client';
-import { useNavigate } from "@tanstack/react-router"
+import { useProfileNavigate } from '$feature/navigate/hooks';
 import { useTranslation } from 'react-i18next';
 /* query */
 import { getProfileByMutableId_QUERY } from '$feature/Profile/graphql';
@@ -37,12 +37,12 @@ function FollowingsModalComponent(props: {
 }) {
     const params = Route.useParams()
     const context = Route.useRouteContext()
-    const navigate = useNavigate()
+    const navigate = useProfileNavigate()
     const { t } = useTranslation()
 
     const title = t("modal.title.followings")
     const handleClickClose = () => {
-        navigate({to: "/profile/$mutableId", params: params})
+        navigate.profileSelect(params.mutableId)
     }
 
     return (

--- a/src/routes/_public/profile/$mutableId/interaction.tsx
+++ b/src/routes/_public/profile/$mutableId/interaction.tsx
@@ -3,7 +3,7 @@ import type { GetProfileByMutableIdQuery } from '$lib/graphql/__generated__/grap
 import type { PropsWithChildren } from 'react';
 /* hooks */
 import { useQuery } from '@apollo/client';
-import { useNavigate } from "@tanstack/react-router"
+import { useProfileNavigate } from '$feature/navigate/hooks';
 import { useTranslation } from 'react-i18next';
 /* query */
 import { getProfileByMutableId_QUERY } from '$feature/Profile/graphql';
@@ -31,12 +31,12 @@ function InteractionModal() {
 
 function InteractionModalComponent(props: PropsWithChildren) {
     const params = Route.useParams()
-    const navigate = useNavigate()
+    const navigate = useProfileNavigate()
     const { t } = useTranslation()
 
     const title = t("modal.title.interaction")
     const handleClickClose = () => {
-        navigate({to: "/profile/$mutableId", params: params})
+        navigate.profileSelect(params.mutableId)
     }
 
     return (

--- a/src/routes/_public/profile/$mutableId/mutualFollowers.tsx
+++ b/src/routes/_public/profile/$mutableId/mutualFollowers.tsx
@@ -3,7 +3,7 @@ import type { DBMiniProfile } from '$feature/Profile/types';
 import type { GetProfileByMutableIdQuery } from '$lib/graphql/__generated__/graphql';
 /* hooks */
 import { useQuery } from '@apollo/client';
-import { useNavigate } from "@tanstack/react-router"
+import { useProfileNavigate } from '$feature/navigate/hooks';
 import { useTranslation } from 'react-i18next';
 /* query */
 import { getProfileByMutableId_QUERY } from '$feature/Profile/graphql';
@@ -42,12 +42,12 @@ function MutualFollowingModalComponent(props: {
 }) {
     const params = Route.useParams()
     const context = Route.useRouteContext()
-    const navigate = useNavigate()
+    const navigate = useProfileNavigate()
     const { t } = useTranslation()
 
     const title = t("modal.title.mutualFollowers")
     const handleClickClose = () => {
-        navigate({to: "/profile/$mutableId", params: params})
+        navigate.profileSelect(params.mutableId)
     }
 
     return (


### PR DESCRIPTION
#### 1. navigate hooks 변경 사항 적용 및 매개변수 추가
- #52
- 변경된 navigate hooks의 내용에 따라 컴포넌트 적용

#### 2. useDescription, useSetPentagramDescription hooks 분리
- #47
- 기존 selector와 handler를 분리하는 코드의 일관성을 위해 분리
- [커밋](https://github.com/fauxRaccord888/litab/pull/47/commits/b16a6ee0ccdaa8c3acfa0cfabee2d21b4a9be5e5)에 먼저 적용되어 있던 내용임

#### 3. ItemIterator 컴포넌트 삭제로 인한 데이터 가공 util 함수 변경
- #51 
- `snapshot` 함수(노드의 timestamp 상의 위치)와 `getUnionedChanges` 함수의 매개변수 변경
- 이에 따른 함수 단순 변경

