### PR TITLE
chore: 주소 기반 tab에서 상태 기반 tab으로 변경에 따른 navigate hooks 수정

### DIFF
--- a/src/feature/navigate/components/NavigationBar.tsx
+++ b/src/feature/navigate/components/NavigationBar.tsx
@@ -1,13 +1,13 @@
 import { useTranslation } from 'react-i18next'
+import { Link } from '@tanstack/react-router'
 import HomeIcon from '$lib/components/icons/HomeIcon'
 import SearchIcon from '$lib/components/icons/SearchIcon'
 import UserIcon from '$lib/components/icons/UserIcon'
 import PentagonIcon from '$lib/components/icons/PentagonIcon'
 import PlusIcon from '$lib/components/icons/PlusIcon'
 
-import { Link } from '@tanstack/react-router'
-
 import "./style/navigationBar.scss"
+
 export default function NavigationBar() {
     const { t } = useTranslation()
     return (

--- a/src/feature/navigate/components/style/navigationBar.scss
+++ b/src/feature/navigate/components/style/navigationBar.scss
@@ -2,16 +2,19 @@
 
 .navigation-bar-component {
     @include flex;
-    @include margin-(calc(var(--base-size) * 0.75));
+    @include padding-wide-(calc(var(--base-size) * 1));
     justify-content: space-between;
     align-items: end;
-    padding-right: calc(var(--base-size) * 2);
-
+    
     @media only screen and (min-width: 500px) {
         @include flex-col;
+        @include align-center;
         min-height: 300px;
     }
-
+    @media only screen and (min-width: 800px) {
+        padding-right: calc(var(--base-size) * 1.5);
+    }
+    
     .navigation-bar-component__link-container {
         @include flex;
         @include align-center;
@@ -25,7 +28,7 @@
         display: none;
         @media only screen and (min-width: 800px) {
             display: inline;
-            min-width: 150px;
+            min-width: 100px;
         }
     }
 

--- a/src/feature/navigate/hooks/useArtistNavigate.ts
+++ b/src/feature/navigate/hooks/useArtistNavigate.ts
@@ -8,17 +8,7 @@ export function useArtistNavigate() {
         navigate({ to: '/artist/$id', params: { id } })
     }, [navigate])
 
-    const oeuvreTabNavigator = useCallback((id: string) => {
-        navigate({ to: '/artist/$id/oeuvre', params: { id } })
-    }, [navigate])
-
-    const followerTabNavigator = useCallback((id: string) => {
-        navigate({ to: '/artist/$id/follower', params: { id } })
-    }, [navigate])
-
     return {
         select: selectNavigator,
-        oeuvreTab: oeuvreTabNavigator,
-        followerTab: followerTabNavigator
     }
 }

--- a/src/feature/navigate/hooks/useGenreNavigate.ts
+++ b/src/feature/navigate/hooks/useGenreNavigate.ts
@@ -8,17 +8,7 @@ export function useGenreNavigate() {
         navigate({ to: '/genre/$id', params: { id } })
     }, [navigate])
 
-    const oeuvreTabNavigator = useCallback((id: string) => {
-        navigate({ to: '/genre/$id/oeuvre', params: { id } })
-    }, [navigate])
-
-    const followerTabNavigator = useCallback((id: string) => {
-        navigate({ to: '/genre/$id/follower', params: { id } })
-    }, [navigate])
-
     return {
         select: selectNavigator,
-        oeuvreTab: oeuvreTabNavigator,
-        followerTab: followerTabNavigator
     }
 }

--- a/src/feature/navigate/hooks/useOeuvreNavigate.ts
+++ b/src/feature/navigate/hooks/useOeuvreNavigate.ts
@@ -8,17 +8,7 @@ export function useOeuvreNavigate() {
         navigate({ to: '/oeuvre/$id', params: { id } })
     }, [navigate])
 
-    const pentagramTabNavigator = useCallback((id: string) => {
-        navigate({ to: '/oeuvre/$id/pentagram', params: { id } })
-    }, [navigate])
-
-    const followerTabNavigator = useCallback((id: string) => {
-        navigate({ to: '/oeuvre/$id/follower', params: { id } })
-    }, [navigate])
-
     return {
         select: selectNavigator,
-        pentagramTab: pentagramTabNavigator,
-        followerTab: followerTabNavigator
     }
 }

--- a/src/feature/navigate/hooks/useProfileNavigate.ts
+++ b/src/feature/navigate/hooks/useProfileNavigate.ts
@@ -24,15 +24,6 @@ export function useProfileNavigate() {
         navigate({to: '/profile/$mutableId/followers', params: { mutableId }})
     }, [navigate])
 
-    const pentagramTabNavigator = useCallback((mutableId: string)=> {
-        navigate({to: '/profile/$mutableId/pentagram', params: { mutableId }})
-    }, [navigate])
-
-    const feedTabNavigator = useCallback((mutableId: string)=> {
-        navigate({to: '/profile/$mutableId/feed', params: { mutableId }})
-    }, [navigate])
-
-
     return {
         profileSelect: profileSelectNavigator,
 
@@ -40,8 +31,5 @@ export function useProfileNavigate() {
         mutualFollowersDetail: mutualFollowersDetailNavigator,
         followingsDetail: followingsDetailHandler,
         followersDetail:followersDetailHandler,
-
-        pentagramTabNavigator: pentagramTabNavigator,
-        feedTab: feedTabNavigator
     }
 }

--- a/src/lib/components/common/Tab/style/tab.scss
+++ b/src/lib/components/common/Tab/style/tab.scss
@@ -3,7 +3,6 @@
 .tab-component {
     @include flex;
     @include flex-col;
-    margin-top: calc(var(--base-size) * 1.5);
 
     .tab-component__header {
         @include flex;
@@ -31,11 +30,11 @@
     }
 
     .tab-component__body {
-        @include child-top-m(calc(var(--base-size) * 0.75));
         border-top: 2px solid rgba(var(--font-color), 0.5);
 
-        .tab-component__item {
-            @include padding-(calc(var(--base-size) * 0.75));
+        > * {
+            @include padding-(calc(var(--base-size) * 1.25));
+            width: calc(100% - calc(var(--base-size) * 2.5));
             border-bottom: 2px solid rgba(var(--font-color), 0.5);
         }
     }


### PR DESCRIPTION
#### 1. 주소 기반 tab에서 상태 기반 tab으로 변경에 따른 수정
- 불필요한 hooks 삭제

#### 2. Tab 하위 컨테이너 삭제에 따른 CSS 변경 
- #63 
- `key가 동반된 반복`을 위해 자녀를 `컨테이너에 담는 대신` Props로 전달된 `JSX.Element를 직접 반환`
- 이에 따른 `css` 변경 진행