### PR TITLE
refactor: InfoCard 템플릿 옵션 추가(컴포넌트 선택 이벤트 핸들러 활성화 옵션)

### DIFF
--- a/src/feature/Artist/components/ArtistSelectView.tsx
+++ b/src/feature/Artist/components/ArtistSelectView.tsx
@@ -47,7 +47,8 @@ export default function ArtistSelectView(props: ArtistSelectViewProps) {
                             }}
                             eventHandler={eventHandler}
                             options={{
-                                miniView: true
+                                miniView: true,
+                                enableSelect: true,
                             }}
                         />
                     )) || []

--- a/src/feature/Genre/components/GenreSelectView.tsx
+++ b/src/feature/Genre/components/GenreSelectView.tsx
@@ -47,7 +47,8 @@ export default function OeuvreSearchView(props: GenreSelectViewProps) {
                                 subInfo: false
                             }}
                             options={{
-                                miniView: true
+                                miniView: true,
+                                enableSelect: true,
                             }}
                         />
                     )) || []

--- a/src/feature/Oeuvre/components/OeuvreNode.tsx
+++ b/src/feature/Oeuvre/components/OeuvreNode.tsx
@@ -43,6 +43,9 @@ export default function OeuvreNode(props: OeuvreNodeProps) {
                                 subInfo: false
                             }}
                             eventHandler={{}}
+                            options={{
+                                enableSelect: true
+                            }}
                         />
                     </div>
                 </HoverCard>

--- a/src/feature/Oeuvre/components/OeuvreSearchView.tsx
+++ b/src/feature/Oeuvre/components/OeuvreSearchView.tsx
@@ -32,6 +32,9 @@ export default function OeuvreSearchView(props: OeuvreSearchViewProps) {
                         eventHandler={{
                             selectOeuvre: () => handleClickResult(item)
                         }}
+                        options={{
+                            enableSelect: true
+                        }}
                     />
                 ))}
             </div>

--- a/src/feature/Oeuvre/components/common/OeuvreInfoCard/OeuvreMainInfo.tsx
+++ b/src/feature/Oeuvre/components/common/OeuvreInfoCard/OeuvreMainInfo.tsx
@@ -32,7 +32,7 @@ export default function OeuvreMainInfo(props: OeuvreMainInfoProps) {
                 eventHandler.selectArtistTag ? "oeuvre-main-info-component__artist--pointer" : ""
             ].join(" ")}
             key={edge.node.artists.id}
-            onClick={(e) => onClickArtist(e, edge.node.artists.id)}
+            onClickCapture={(e) => onClickArtist(e, edge.node.artists.id)}
         >
             {edge.node.artists.name}
         </span>
@@ -46,7 +46,7 @@ export default function OeuvreMainInfo(props: OeuvreMainInfoProps) {
         return (
             <span 
                 key={edge.node.genres.id}
-                onClick={(e) => onClickGenre(e, edge.node.genres.id)}
+                onClickCapture={(e) => onClickGenre(e, edge.node.genres.id)}
                 className={[
                     "oeuvre-main-info-component__artist",
                     isLightFont ? "light-font-color" : "",

--- a/src/feature/Profile/components/modal/MiniProfileModal.tsx
+++ b/src/feature/Profile/components/modal/MiniProfileModal.tsx
@@ -24,7 +24,8 @@ export default function MiniProfileModal(props: MiniProfileModalProps) {
                         item={item}
                         context={context}
                         options={{
-                            displayFollow: true
+                            displayFollow: true,
+                            enableSelect: true
                         }}
                     />
                 ))}

--- a/src/feature/template/components/InfoCardTemplate.tsx
+++ b/src/feature/template/components/InfoCardTemplate.tsx
@@ -1,5 +1,5 @@
 import type { ISlotComponent, ISlotRenderConfig } from "../type"
-import type { MouseEventHandler } from "react"
+import type { MouseEvent } from "react"
 import { filterComponents } from "../util"
 import "./style/infoCard.scss"
 
@@ -7,7 +7,10 @@ export type InfoCardRenderConfigKey = "coverImage" | "title" | "mainInfo" | "sub
 
 export type InfoCardOptions = {
     miniView?: boolean,
-    roundedCover?: boolean    
+    roundedCover?: boolean,
+    // COMMENT Oeuvre 컴포넌트의 경우, Oeuvre 엔티티가 2번 사용됨(작품 자체, 작품 관련 펜타그램의 호버카드)
+    // 이 경우, 동일한 이벤트 핸들러를 사용하므로 아이템 클릭 가능 여부를 이벤트 핸들러만으로 판단할 수 없음
+    enableSelect?: boolean 
 }
 
 type InfoCardProps = {
@@ -15,12 +18,17 @@ type InfoCardProps = {
     components: ISlotComponent<InfoCardRenderConfigKey>,
     renderConfig: ISlotRenderConfig<InfoCardRenderConfigKey>,
     options?: InfoCardOptions,
-    onClick?: MouseEventHandler<HTMLDivElement>
+    onClick?: ((id: string) => void) | undefined | null
 }
 
 export default function InfoCardTemplate(props: InfoCardProps) {
-    const { components, renderConfig, options, onClick, ...restProps } = props
+    const { id, components, renderConfig, options, onClick, ...restProps } = props
     const filteredComponents = filterComponents<InfoCardRenderConfigKey>(components, renderConfig)
+
+    const onClickItem = (e: MouseEvent) => {
+        e.preventDefault()
+        if (onClick && options?.enableSelect) onClick(id)
+    }
 
     return (
         <div 
@@ -28,7 +36,9 @@ export default function InfoCardTemplate(props: InfoCardProps) {
             className={[
                 "info-card-template",
                 options?.miniView ? "mini-view" : "",
+                (onClick && options?.enableSelect) ? "info-card-template__main-container--pointer" :""
             ].join(" ")}
+            onClick={onClickItem}
         >
             {filteredComponents?.coverImage &&
                 <div 
@@ -68,13 +78,7 @@ export default function InfoCardTemplate(props: InfoCardProps) {
                                 filteredComponents.mainInfo) &&
                                     <div className="info-card-template__main-info-container" >
                                         {filteredComponents.title &&                                    
-                                            <div 
-                                                className={[
-                                                    "info-card-template__title",
-                                                    onClick ? "info-card-template__title--pointer" :""
-                                                ].join(" ")}
-                                                onClick={onClick}
-                                            >
+                                            <div className="info-card-template__title">
                                                 {filteredComponents.title}
                                             </div>
                                         }

--- a/src/feature/template/components/style/infoCard.scss
+++ b/src/feature/template/components/style/infoCard.scss
@@ -15,6 +15,10 @@
         @include child-left-m(calc(var(--base-size) * 1.25));
     }
 
+    &.info-card-template__main-container--pointer {
+        @include pointer;
+    }
+
     .info-card-template__cover-container {
         @include flex;
         @include align-center;
@@ -92,10 +96,6 @@
                     @include flex;
                     @include align-center;
                     font-size: calc(var(--base-size) * 1.5);
-
-                    &.info-card-template__title--pointer {
-                        @include pointer;
-                    }
                 }
             }
         }


### PR DESCRIPTION
#### 1.  InfoCard 템플릿 옵션 추가(컴포넌트 선택 이벤트 핸들러 활성화 옵션)
- 재귀적으로 `같은 handler를 활용`해야 하는 경우가 존재
- 같은 엔티티를 2번 이상 쓰는, `중첩된 구조의 컴포넌트`
- 대표적으로 OeuvreSelectView에서
    - PentagramSelectView를 호출하고 
    - 그 안에서 `OeuvreInfoCard` 컴포넌트를 다시 호출함
- 물론 기술적으로 `option 없이 해결할 수는 있음`  
    - `OeuvreSelectView` 스코프의 
        - `OeuvreInfoCard에서 EventHandler에서 
        - `작품 선택` 관련 핸들러만 제외하고 전달하면 해결
- 이러한 경우, 왜 이벤트 핸들러를 변형하는지 별도의 주석이 필요함
    - 주석으로도 불충분하며 특정 컴포넌트를 사용했는데 다른 작동으로 인해 디버깅이 길어질 수 있음
    - 옵션으로 명시적으로 작동하도록 만드는 편이 추후 활용을 위해 용이할 것으로 판단