### PR TITLE
refactor: 쓰로틀 hooks Promise화

### DIFF
--- a/src/lib/hooks/toaster/useThrottledErrorToast.ts
+++ b/src/lib/hooks/toaster/useThrottledErrorToast.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from "react"
 import { useTranslation } from "react-i18next"
-import { CustomError } from "$lib/error"
+import { isCustomError, isError } from "$lib/utils"
 import toast from "react-hot-toast"
 
 export function useThrottledErrorToast<T>(ms: number=1000) {
@@ -22,11 +22,11 @@ export function useThrottledErrorToast<T>(ms: number=1000) {
                 timeoutRef.current = null
             }
 
-            if (error instanceof CustomError) {
+            if (isCustomError(error)) {
                 toast.error(t(error.i18nKey))
                 return
             }
-            if (error instanceof Error) {
+            if (isError(error)) {
                 toast.error(t(error.message))
                 return
             }


### PR DESCRIPTION
#### 1. 쓰로틀 hooks Promise화
- 기존에는 `timeout`에서 `에러를 발생`시키면 `바깥 스코프`에서 받을 수 없음
- timeout 스코프에서 바로 Toast 처리하는 방식을 사용
- 이는 `에러에 대한 처리`와 `쓰로틀에 대한 처리`를 분리하지 못한 결과물 
- 코드의 일관성과 유연성을 해치는 부분이므로 리팩토링