### PR TITLE
feat: 스토리지 이미지 업로드 기능 추가 및 캐시 버스팅 매개변수 추가

### DIFF
--- a/src/feature/Artist/components/common/ArtistInfoCard/index.tsx
+++ b/src/feature/Artist/components/common/ArtistInfoCard/index.tsx
@@ -14,11 +14,11 @@ type ArtistInfoCardProps = {
 
 export default function ArtistInfoCard(props: ArtistInfoCardProps) {
     const { item, renderConfig, eventHandler } = props
-    const { id, name, abstract, bio } = item
+    const { id, name, abstract, bio, updated_at } = item
 
     const coverImage = useMemo(() => (
-        <BucketImage bucket="artists" id={id} fallback={<FallbackIcon />} />
-    ), [id])
+        <BucketImage bucket="artists" timeStamp={updated_at} id={id} fallback={<FallbackIcon />} />
+    ), [id, updated_at])
 
     return (
         <div className="artist-info-card-component">

--- a/src/feature/Artist/graphql/fragment.ts
+++ b/src/feature/Artist/graphql/fragment.ts
@@ -4,6 +4,7 @@ graphql(/* GraphQL */ `
     fragment ArtistsMinimalInfo on artists {
         id
         name
+        updated_at
     }
 `)
 

--- a/src/feature/Genre/components/common/GenreInfoCard/index.tsx
+++ b/src/feature/Genre/components/common/GenreInfoCard/index.tsx
@@ -14,11 +14,11 @@ type GenreInfoCardProps = {
 
 export default function GenreInfoCard(props: GenreInfoCardProps) {
     const { item, renderConfig, eventHandler } = props
-    const { id, name, abstract, description } = item
+    const { id, name, abstract, updated_at, description } = item
 
     const coverImage = useMemo(() => (
-        <BucketImage bucket="genres" id={id} fallback={<FallbackIcon />} />
-    ), [id])
+        <BucketImage bucket="genres" timeStamp={updated_at} id={id} fallback={<FallbackIcon />} />
+    ), [id, updated_at])
 
 
     return (

--- a/src/feature/Genre/graphql/fragment.ts
+++ b/src/feature/Genre/graphql/fragment.ts
@@ -4,6 +4,7 @@ graphql(/* GraphQL */ `
     fragment GenresMinimalInfo on genres {
         id
         name
+        updated_at
     }
 `)
 

--- a/src/feature/Oeuvre/components/OeuvreNode.tsx
+++ b/src/feature/Oeuvre/components/OeuvreNode.tsx
@@ -56,6 +56,7 @@ export default function OeuvreNode(props: OeuvreNodeProps) {
                 <BucketImage 
                     bucket="oeuvres"
                     id={item.id}
+                    timeStamp={item.updated_at}
                     fallback={<FallbackIcon />}
                 />
             </div>

--- a/src/feature/Oeuvre/components/common/OeuvreInfoCard/index.tsx
+++ b/src/feature/Oeuvre/components/common/OeuvreInfoCard/index.tsx
@@ -16,11 +16,11 @@ type OeuvreInfoProps = {
 
 export default function OeuvreInfoCard(props: OeuvreInfoProps) {
     const { item, renderConfig, options, eventHandler } = props
-    const { id, title, description } = item
+    const { id, title, description, updated_at } = item
 
     const coverImage = useMemo(() => (
-        <BucketImage bucket="oeuvres" id={id} fallback={<FallbackIcon />} />
-    ), [id])
+        <BucketImage bucket="oeuvres" timeStamp={updated_at} id={id} fallback={<FallbackIcon />} />
+    ), [id, updated_at])
 
     const mainInfo = useMemo(() => (
         <OeuvreMainInfo 

--- a/src/feature/Oeuvre/graphql/fragment.ts
+++ b/src/feature/Oeuvre/graphql/fragment.ts
@@ -4,6 +4,7 @@ graphql(/* GraphQL */ `
     fragment OeuvresMinimalInfo on oeuvres {
         id
         title
+        updated_at
     }
 `)
 

--- a/src/feature/Profile/components/UserInfoCard/index.tsx
+++ b/src/feature/Profile/components/UserInfoCard/index.tsx
@@ -21,7 +21,7 @@ type ProfileInfoCardProps = {
 
 export default function ProfileInfoCard(props: ProfileInfoCardProps) {
     const { item, context, renderConfig, options, eventHandler } = props
-    const { id, mutable_id, nickname, description, followersCollection, followingsCollection } = item
+    const { id, mutable_id, nickname, description, updated_at, followersCollection, followingsCollection } = item
 
     const followings = calcFollowings(context.currentUser)
     const mutualFollowers = calcMutualFollowers(context.currentUser, item, followings)
@@ -32,6 +32,7 @@ export default function ProfileInfoCard(props: ProfileInfoCardProps) {
         <ProfileCoverImage 
             id={id} 
             mutable_id={mutable_id}
+            updated_at={updated_at}
             eventHandler={eventHandler}
         />
     )

--- a/src/feature/Profile/components/common/ProfileCoverImage.tsx
+++ b/src/feature/Profile/components/common/ProfileCoverImage.tsx
@@ -7,13 +7,14 @@ import BucketImage from "$lib/components/common/BucketImage"
 
 type ProfileCoverImageProps = {
     id: DBProfiles["id"]
-    mutable_id: DBProfiles["mutable_id"]
+    mutable_id: DBProfiles["mutable_id"],
+    updated_at: DBProfiles["updated_at"],
     eventHandler: ProfileEventHandler
     className?: string,
 }
 
 export default function ProfileCoverImage(props: ProfileCoverImageProps) {
-    const { id, mutable_id, eventHandler, className } = props
+    const { id, mutable_id, updated_at, eventHandler, className } = props
     
     const onClickProfile = (e: MouseEvent) => {
         e.stopPropagation()
@@ -24,7 +25,8 @@ export default function ProfileCoverImage(props: ProfileCoverImageProps) {
         <BucketImage
             id={id}
             onClick={onClickProfile}
-            bucket="profiles"
+            bucket="users"
+            timeStamp={updated_at}
             className={className}
             fallback={<UserIcon className="profile-cover-image-component__fallback-image"/>}
         />

--- a/src/feature/Profile/graphql/fragment.ts
+++ b/src/feature/Profile/graphql/fragment.ts
@@ -4,7 +4,8 @@ graphql(/* GraphQL */ `
     fragment MiniProfile on users {
         mutable_id,
         nickname,
-        id
+        id,
+        updated_at
     }
 `)
 

--- a/src/lib/components/common/BucketImage.tsx
+++ b/src/lib/components/common/BucketImage.tsx
@@ -1,38 +1,32 @@
 import type { MouseEvent } from "react";
+import type { BucketKeys } from "$lib/supabase";
 import { useState } from "react"
-import { getURLfromBucket } from "$lib/supabase/storage"
+import { getURLfromBucket } from "$lib/supabase"
 import "./style/bucketImage.scss"
 
-export type BucketKeys = 'profiles' | 'oeuvres' | "artists" | "genres"
 export interface BucketImageProps {
-    id: string
+    id: string,
     bucket: BucketKeys
+    timeStamp?: string | null | undefined
     fallback?: JSX.Element
     className?: string,
     onClick?: (e: MouseEvent) => void
 }
 
 export default function BucketImage(props: BucketImageProps) {
-    const { id, fallback, bucket, className, onClick, ...restProps } = props
+    const { id, fallback, bucket, timeStamp, className, onClick, ...restProps } = props
     const [error, setError] = useState(false)
-    const url = getURLfromBucket({id, bucket, file: FILE[bucket]})
+    const url = timeStamp ? getURLfromBucket({id, bucket, timeStamp}) : null
 
     return (
         <div 
             onClick={onClick} 
             className={`${className || ""} bucket-image-component`}
         >
-            {!error && 
+            {(!error && url )&&
                 <img draggable={false} className="image" {...restProps} src={url} loading="lazy" onError={() => setError(true)}/>
             }
-            {error && fallback}
+            {(error || !url) && fallback}
         </div>
     )
-}
-
-const FILE: Record<BucketKeys, string> = {
-    profiles: 'profile.jpg',
-    oeuvres: 'cover.jpg',
-    artists: "profile.jpg",
-    genres: "cover.jpg"
 }

--- a/src/lib/supabase/storage.ts
+++ b/src/lib/supabase/storage.ts
@@ -1,15 +1,16 @@
 import { supabaseClient } from "./client"
 
 export const getURLfromBucket = ( payload: {
-    bucket: string
+    bucket: string,
     id: string,
-    file: string,
+    timeStamp: string
 }) => {
-    const { bucket, id, file } = payload
+    const { bucket, id, timeStamp } = payload
+    const t = new Date(timeStamp).getTime() 
     const { data } = supabaseClient
         .storage
         .from(bucket)
-        .getPublicUrl(`${id}/${file}`)
+        .getPublicUrl(`public/${id}?t=${t}`)
     
     return data.publicUrl
 }

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -1,0 +1,1 @@
+export type BucketKeys = 'users' | 'oeuvres' | "artists" | "genres"

--- a/src/lib/supabase/upload.ts
+++ b/src/lib/supabase/upload.ts
@@ -1,0 +1,46 @@
+import type { BucketKeys } from "./types"
+import { supabaseClient } from "./client"
+import { CustomUnknownError } from '$lib/error';
+
+// COMMENT 
+// DB에 트리거를 두어 update 시에 table을 업데이트하는 것이 기술적으로는 가능함
+// https://github.com/orgs/supabase/discussions/19017#discussioncomment-7613197
+// 그러나 위의 토론에서 지적하듯, Supabase의 storage schema는 잦은 변화에 노출됨
+// 하나의 transaction으로 묶을 수 없지만 그럼에도 클라이언트에서 처리하는 것이 바람직할 것으로 판단됨
+
+
+// TODO 
+// REFACTOR
+// 둘로 나뉜 업데이트 과정(table, storage)에 대한 에러 핸들링이 적절히 이루어지지 않음
+// 현실적으로 storage가 성공했을 때 table update가 실패할 확률은 낮지만 문제
+
+export const upload_SUPABASE = async (
+    payload: {
+        file: File,
+        bucket: BucketKeys,
+        id: string | null | undefined
+    },
+) => {
+    const { file, bucket, id } = payload
+    if (!id) return { data: null, error: new CustomUnknownError()}
+    
+    const t = new Date()
+    const { data: storageData, error: storageError } = await supabaseClient
+        .storage
+        .from(bucket)
+        .upload(`public/${id}?t=${t.getTime()}`, file, {
+            cacheControl: '3600',
+            upsert: true
+        })
+    if (storageError) return { data: null, error: storageError }
+
+    const { error: tableError } = await supabaseClient
+        .from(bucket)
+        .update({'updated_at': String(t.toISOString()) })
+        .eq('id', id)
+    if (tableError) return { data: null, error: tableError}
+
+    return {
+        data: storageData, error: null
+    }
+}


### PR DESCRIPTION
#### 1. 스토리지 업로드 함수 추가
- `supabase` 이외의 스토리지로 마이그레이션할 수 있기 때문에 함수 별도 분리

#### 2. 캐시 버스팅용 매개변수 추가
- 이미지 업데이트 시, 확인을 위해 매개변수 추가
- 관련 필드를 `컴포넌트`와 `GraphQl 쿼리 필드`에 추가 