### PR TITLE
fix: Revision 데이터 fetch 시, 캐시 miss 문제 해결

### DIFF
--- a/src/feature/Pentagram/graphql/fragments/revisions.ts
+++ b/src/feature/Pentagram/graphql/fragments/revisions.ts
@@ -8,6 +8,7 @@ graphql(/* GraphQL */ `
             id
         }
         pentagram_revision_update_recordsCollection {
+            totalCount
             edges {
                 node {
                     ...UpdateRecordInfo
@@ -15,6 +16,7 @@ graphql(/* GraphQL */ `
             }
         }
         pentagram_revision_upsert_recordsCollection {
+            totalCount
             edges {
                 node {
                     ...UpsertRecordInfo
@@ -22,6 +24,7 @@ graphql(/* GraphQL */ `
             }
         }
         pentagram_revision_remove_recordsCollection {
+            totalCount
             edges {
                 node {
                     ...RemoveRecordInfo
@@ -29,6 +32,7 @@ graphql(/* GraphQL */ `
             }
         }
         pentagram_revision_recover_recordsCollection {
+            totalCount
             edges {
                 node {
                     ...RecoverRecordInfo


### PR DESCRIPTION
#### 1. 문제 설명 
- `Revision` 엔티티 fetch 시, `fragment` 캐시가 존재함에도 지속적인 `refetch` 발생 
- 상세 fragment에 totalCount를 넣지 않아서 대체하면서 생긴 문제