### PR TITLE
fix: 펜타그램 인포카드 클릭 시, 잘못된 주소로 라우팅되는 문제 해결

### DIFF
--- a/src/feature/Profile/components/UserInfoCard/index.tsx
+++ b/src/feature/Profile/components/UserInfoCard/index.tsx
@@ -30,6 +30,11 @@ export default function ProfileInfoCard(props: ProfileInfoCardProps) {
     const isMe = currentUser?.id === id
     const followed = followings?.has(id)
 
+    const handleClickProfile = () => {
+        if (!eventHandler.selectProfile) return
+        eventHandler?.selectProfile(mutable_id)
+    }
+
     const coverImage = (
         <ProfileCoverImage 
             id={id} 
@@ -82,7 +87,7 @@ export default function ProfileInfoCard(props: ProfileInfoCardProps) {
         <div className="user-info-card-component">
             <InfoCardTemplate 
                 id={item.id}
-                onClick={eventHandler.selectProfile}
+                onClick={handleClickProfile}
                 renderConfig={renderConfig}
                 components={{
                     coverImage,


### PR DESCRIPTION
- 다른 info card의 경우 id 기반의 라우팅임에 반해, 프로필의 경우 mutable_id를 기반으로 하여 발생한 문제