### PR TITLE
refactor: 펜타그램 플레이어 재생 로직 정확도 개선, hooks 내부화, 재생 표시 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "dependencies": {
     "@apollo/client": "^3.8.10",
     "@graphql-tools/schema": "^10.0.2",
+    "@graphql-typed-document-node/core": "^3.2.0",
+    "@react-spring/web": "^9.7.3",
     "@reduxjs/toolkit": "^2.1.0",
     "@supabase/storage-js": "^2.5.5",
     "@supabase/supabase-js": "^2.39.3",
@@ -22,7 +24,8 @@
     "react-dom": "^18.2.0",
     "react-hot-toast": "^2.4.1",
     "react-redux": "^9.1.0",
-    "redux-persist": "^6.0.0"
+    "redux-persist": "^6.0.0",
+    "usehooks-ts": "^3.0.2"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^5.0.0",

--- a/src/feature/Oeuvre/components/OeuvreSelectView.tsx
+++ b/src/feature/Oeuvre/components/OeuvreSelectView.tsx
@@ -3,7 +3,6 @@ import type { BaseEventHandler } from '$lib/types/components';
 import type { PentagramEventHandler } from '$feature/Pentagram/types';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { TIME } from '$feature/Pentagram/constants';
 
 import SelectViewTemplate from '$feature/template/components/SelectViewTemplate';
 import OeuvreInfoCard from './common/OeuvreInfoCard';
@@ -48,7 +47,6 @@ export default function OeuvreSelectView(props: OeuvreSelectViewProps) {
                 }}
                 eventHandler={eventHandler}
                 options={{}}
-                timestamp={new Date(Date.now() + TIME.NOW_OFFSET)}
             />
         )) || []
     ), [eventHandler, item?.pentagram_nodesCollection?.edges])

--- a/src/feature/Pentagram/components/PentagramCard/SelectMainPentagon/PentagramNode.tsx
+++ b/src/feature/Pentagram/components/PentagramCard/SelectMainPentagon/PentagramNode.tsx
@@ -30,7 +30,7 @@ export default function PentagramNode(props: PentagramNodeProps) {
             !deleted &&
             typeof angle === 'number' &&
             typeof distance === 'number' &&
-                <PositionAdjuster angle={angle} distance={distance}>
+                <PositionAdjuster position={{angle, distance, deleted: false}}>
                     <div
                         className="pentagram-node-component"
                         onClick={onClickNode}

--- a/src/feature/Pentagram/components/PentagramCard/SelectPlayer/index.tsx
+++ b/src/feature/Pentagram/components/PentagramCard/SelectPlayer/index.tsx
@@ -1,16 +1,17 @@
-import type { DBPentagram_SELECT, PentagramEventHandler } from "../../../types";
+import type { DBPentagram_SELECT, PentagramPlayerEventHandler } from "../../../types";
 import { useMemo } from "react";
 import PlayIcon from '$lib/components/icons/PlayIcon';
 import "./style/selectPlayer.scss"
 
 type SelectPlayerProps = {
     timestamp: Date
+    isPlaying: boolean
     pentagram_revisionsCollection: DBPentagram_SELECT["pentagram_revisionsCollection"],
-    eventHandler: PentagramEventHandler
+    eventHandler: PentagramPlayerEventHandler
 }
 
 export default function SelectPlayer(props: SelectPlayerProps) {    
-    const { timestamp, pentagram_revisionsCollection, eventHandler } = props
+    const { timestamp, isPlaying, pentagram_revisionsCollection, eventHandler } = props
 
     const timestamps = useMemo(() => (
         pentagram_revisionsCollection?.edges
@@ -33,7 +34,13 @@ export default function SelectPlayer(props: SelectPlayerProps) {
     return (
         <div className="select-player-component">
             <div className="select-player-component__inner-container">
-                <div className="select-player-component__play-button" onClick={onClickPlay}>
+                <div 
+                    className={[
+                        "select-player-component__play-button",
+                        isPlaying ? "select-player-component__play-button--playing" : ""
+                    ].join(" ")}
+                    onClick={onClickPlay}
+                >
                     <PlayIcon />
                 </div>
                 <div className="select-player-component__progress-bar">

--- a/src/feature/Pentagram/components/PentagramCard/SelectPlayer/style/selectPlayer.scss
+++ b/src/feature/Pentagram/components/PentagramCard/SelectPlayer/style/selectPlayer.scss
@@ -14,6 +14,10 @@
         .select-player-component__play-button {
             fill: rgba(var(--font-color));
             width: calc(var(--base-size) * 2.5);
+
+            &.select-player-component__play-button--playing{
+                fill: rgba(var(--primary), 0.9);
+            }
         }
     
         .select-player-component__progress-bar {
@@ -25,6 +29,7 @@
             background-color: rgba(var(--font-color), 0.2);
             .select-player-component__progress-node {
                 @include rounded-full;
+                @include pointer;
                 background-color: rgba(var(--font-color), 0.5);
                 width: calc(var(--base-size) * 0.8);
                 height: calc(var(--base-size) * 0.8);

--- a/src/feature/Pentagram/components/PentagramCard/index.tsx
+++ b/src/feature/Pentagram/components/PentagramCard/index.tsx
@@ -1,5 +1,6 @@
-import type { DBPentagram_SELECT, PentagramEventHandler, PentagramSelectOptions, PentagramSelectRenderConfig } from "../../types";
+import type { DBPentagram_SELECT, PentagramEventHandler, PentagramPlayerEventHandler, PentagramSelectOptions, PentagramSelectRenderConfig } from "../../types";
 import type { OeuvreEventHandler } from "$feature/Oeuvre/types";
+import { usePentagramPlayer } from "$feature/Pentagram/hooks";
 
 import SelectMetaInfo from "./SelectMetaInfo";
 import SelectMainPentagon from "./SelectMainPentagon";
@@ -13,12 +14,17 @@ export type PentagramCardProps = {
     options: PentagramSelectOptions,
     renderConfig: PentagramSelectRenderConfig,
     eventHandler: PentagramEventHandler & OeuvreEventHandler,
-    timestamp: Date
 }
 
 export default function PentagramCard(props: PentagramCardProps) {
-    const { item, renderConfig, options, eventHandler, timestamp } = props
+    const { item, renderConfig, options, eventHandler } = props
+    const { timestamp, isPlaying, handlePlayPentagram, handleSetTimestamp } = usePentagramPlayer(item)
     const { id, users, created_at, description, pentagram_nodesCollection, pentagram_revisionsCollection } = item
+
+    const playerEventHandler: PentagramPlayerEventHandler = {
+        playPentagram: handlePlayPentagram,
+        setTimestamp: handleSetTimestamp
+    }
 
     return (
         <div className="pentagram-card-component">
@@ -41,8 +47,9 @@ export default function PentagramCard(props: PentagramCardProps) {
                 <div className="pentagram-card-component__description-container">
                     <SelectPlayer 
                         timestamp={timestamp}
+                        isPlaying={isPlaying}
                         pentagram_revisionsCollection={pentagram_revisionsCollection} 
-                        eventHandler={eventHandler} 
+                        eventHandler={playerEventHandler} 
                     />
                 </div>
             }

--- a/src/feature/Pentagram/components/PentagramSelectView.tsx
+++ b/src/feature/Pentagram/components/PentagramSelectView.tsx
@@ -1,17 +1,15 @@
 import type { DBPentagram_SELECT, PentagramEventHandler, PentagramSelectOptions } from '../types';
-import { TIME } from '$feature/Pentagram/constants';
 import PentagramCard from '$feature/Pentagram/components/PentagramCard';
 import './style/pentagramSelectView.scss'
 
 type PentagramSelectViewProps = {
     item: DBPentagram_SELECT,
     eventHandler: PentagramEventHandler
-    timestamp?: Date
     options?: PentagramSelectOptions,
 }
 
 export default function PentagramSelectView(props: PentagramSelectViewProps) {
-    const { item, eventHandler, timestamp, options } = props
+    const { item, eventHandler, options } = props
 
     return (
         <div className="pentagram-select-view-component">
@@ -27,7 +25,6 @@ export default function PentagramSelectView(props: PentagramSelectViewProps) {
                     }}
                     eventHandler={eventHandler}
                     options={{...options}}
-                    timestamp={timestamp ?? new Date(Date.now() + TIME.NOW_OFFSET)}
                 />
             </div>
         </div>

--- a/src/feature/Pentagram/components/PentagramUpsertView/PentagramUpsertEditor/UpdateMainPentagon/MergedNode.tsx
+++ b/src/feature/Pentagram/components/PentagramUpsertView/PentagramUpsertEditor/UpdateMainPentagon/MergedNode.tsx
@@ -43,7 +43,7 @@ export default function MergedNode(props: MergedNodeProps) {
     return (
         <>
             {item &&
-                <PositionAdjuster behind={deleted} angle={angle} distance={distance}>
+                <PositionAdjuster behind={deleted} position={{ angle, distance, deleted }}>
                     <div
                         className={className}
                         // selecte node event

--- a/src/feature/Pentagram/components/PentagramUpsertView/PentagramUpsertEditor/UpdateMainPentagon/SelectedPosition.tsx
+++ b/src/feature/Pentagram/components/PentagramUpsertView/PentagramUpsertEditor/UpdateMainPentagon/SelectedPosition.tsx
@@ -34,7 +34,7 @@ export default function SelectedPosition(props: SelectedPositionProps) {
             {
                 typeof angle === 'number' && 
                 typeof distance === 'number' &&
-                <PositionAdjuster angle={angle} distance={distance}>
+                <PositionAdjuster position={{ angle, distance, deleted: false }}>
                     <div 
                         onClick={onClickSelectedPosition}
                         draggable={true}

--- a/src/feature/Pentagram/components/common/PositionAdjuster.tsx
+++ b/src/feature/Pentagram/components/common/PositionAdjuster.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties, PropsWithChildren } from 'react';
+import type { PentagramNodePosition } from '../../types';
 import './style/positionAdjuster.scss'
 
 interface NodeStyle extends CSSProperties {

--- a/src/feature/Pentagram/components/common/PositionAdjuster.tsx
+++ b/src/feature/Pentagram/components/common/PositionAdjuster.tsx
@@ -7,17 +7,16 @@ interface NodeStyle extends CSSProperties {
 }
 
 interface PositionAdjusterProps extends PropsWithChildren{
-    angle: number,
-    distance: number, 
+    position: PentagramNodePosition
     behind?: boolean | null | undefined
 }
 
 export default function PositionAdjuster(props: PositionAdjusterProps) {
-    const { angle, distance, behind, ...restProps } = props
+    const { position, behind, ...restProps } = props
 
     const style: NodeStyle = {
-        '--distance-multiplier': (distance || 0) / 100,
-        '--degrees': `${angle || 0}deg`
+        '--distance-multiplier': (position.distance || 0) / 100,
+        '--degrees': `${position.angle || 0}deg`
     }
 
     return (

--- a/src/feature/Pentagram/constants.ts
+++ b/src/feature/Pentagram/constants.ts
@@ -12,5 +12,5 @@ export const PENTAGRAM = {
 
 export const TIME = {
     NOW_OFFSET: 10000,
-    PLAY_PENTAGRAM_INTERVAL: 300,
+    PLAY_PENTAGRAM_INTERVAL: 500,
 }

--- a/src/feature/Pentagram/types.ts
+++ b/src/feature/Pentagram/types.ts
@@ -16,6 +16,15 @@ export type PentagramEventHandler = {
     pentagramMenuModal?: (pentagramId: string) => void,
     nodeSelectModal?: (nodeId: string) => void,
     revisionSelectModal?: (revisionId: string) => void,
+}
+
+export type PentagramPlayerEventHandler = {
     setTimestamp?: (date: Date) => void
     playPentagram?: (interval?: number) => void
+}
+
+export type PentagramNodePosition = {
+    angle: number | null | undefined;
+    distance: number | null | undefined;
+    deleted: boolean | null | undefined;
 }

--- a/src/feature/Pentagram/utils/components/getSnapshot.ts
+++ b/src/feature/Pentagram/utils/components/getSnapshot.ts
@@ -3,12 +3,15 @@ import { getUnionedChanges } from '.';
 
 export function getSnapshot(
     unionedChanges: ReturnType<typeof getUnionedChanges>,
-    timestamp: Date
+    timestamp: Date,
+    calcBeforePosition?: boolean
 ) {
     const position = unionedChanges.find((change) => {
         if (!change) return false
         if (!change?.created_at) return false
-        if (new Date(change?.created_at) > timestamp) return false
+        const date = new Date(change?.created_at)
+        if (date > timestamp) return false
+        if (calcBeforePosition && date >= timestamp) return false
         if (typeof change?.current_angle !== 'number') return false
         if (typeof change?.current_distance !== 'number') return false
         return true

--- a/src/feature/Profile/components/ProfileSelctView.tsx
+++ b/src/feature/Profile/components/ProfileSelctView.tsx
@@ -5,7 +5,6 @@ import type { BaseEventHandler } from '$lib/types/components';
 
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { TIME } from '$feature/Pentagram/constants';
 import { NETWORK } from '$lib/constants';
 
 import SelectViewTemplate from '$feature/template/components/SelectViewTemplate';
@@ -61,7 +60,6 @@ export default function ProfileSelectView(props: {
                 }}
                 eventHandler={eventHandler}
                 options={{}}
-                timestamp={new Date(Date.now() + TIME.NOW_OFFSET)}
             />
         )) || []
     ), [eventHandler, item?.pentagramsCollection?.edges])

--- a/src/feature/feed/components/FeedItem.tsx
+++ b/src/feature/feed/components/FeedItem.tsx
@@ -38,7 +38,6 @@ export default function FeedItem(props: FeedItemProps) {
                 options={{
                     displayRevisionIds: [id],
                 }}
-                timestamp={new Date(item.created_at)}
                 eventHandler={eventHandler}
             />
         )

--- a/src/lib/hooks/useCSSVariables.ts
+++ b/src/lib/hooks/useCSSVariables.ts
@@ -1,0 +1,26 @@
+import { useMediaQuery } from "usehooks-ts";
+import { STYLE } from "$lib/style/variables";
+
+export function useCSSVariables() {
+    const lg = useMediaQuery(`only screen and (min-width : ${STYLE.BREAK_POINT.MD}px)`);
+    const md = useMediaQuery(`only screen and (min-width : ${STYLE.BREAK_POINT.SM}px)`);
+
+    if (lg) {
+        return {
+            ...STYLE.COMMON,
+            ...STYLE.LG
+        }
+    }
+
+    if (md) {
+        return {
+            ...STYLE.COMMON,
+            ...STYLE.MD
+        }
+    }
+
+    return {
+        ...STYLE.COMMON,
+        ...STYLE.SM
+    }
+}

--- a/src/lib/style/_variables.scss
+++ b/src/lib/style/_variables.scss
@@ -1,3 +1,4 @@
+// /variables.ts와 반드시 같이 수정
 $node_small: 36;
 $node_medium: 64;
 

--- a/src/lib/style/variables.ts
+++ b/src/lib/style/variables.ts
@@ -1,0 +1,19 @@
+// /_variables.scss와 반드시 함께 수정
+export const STYLE = {
+    BREAK_POINT: {
+        SM: 500,
+        MD: 800,
+    },
+    SM: {
+        NODE: 36
+    },
+    MD: {
+        NODE: 64
+    },
+    LG: {
+        NODE: 64
+    },
+    COMMON: {
+        PENTAGON_ANGLE_OFFSET: 270,
+    }
+}

--- a/src/routes/_public/pentagram/$pentagramId/view.tsx
+++ b/src/routes/_public/pentagram/$pentagramId/view.tsx
@@ -2,7 +2,6 @@ import type { GetPentagramSelectInfoByIdQuery } from '$lib/graphql/__generated__
 import type { PentagramEventHandler } from '$feature/Pentagram/types';
 import type { OeuvreEventHandler } from '$feature/Oeuvre/types';
 import { useQuery } from '@apollo/client';
-import { usePentagramPlayer } from '$feature/Pentagram/hooks';
 import { useOeuvreNavigate, usePentagramNavigate, useRedirectOnError } from "$feature/navigate/hooks"
 import { t as translate } from 'i18next'
 import { getPentagramSelectInfoById_QUERY } from '$feature/Pentagram/graphql';
@@ -28,7 +27,6 @@ function PentagramSelect() {
 
     const pentagramNavigate = usePentagramNavigate();
     const oeuvreNavigate = useOeuvreNavigate();
-    const { timestamp, handlePlayPentagram, handleSetTimestamp } = usePentagramPlayer(item)
     useRedirectOnError(Boolean(
         (data && !item) 
         || error
@@ -39,8 +37,6 @@ function PentagramSelect() {
         nodeSelectModal: (nodeId: string) => pentagramNavigate.nodeSelectModal(nodeId),
         revisionSelectModal: (revisionId: string) => pentagramNavigate.revisionSelectModal(revisionId),
         selectOeuvre: (oeuvreId: string) => oeuvreNavigate.select(oeuvreId),
-        setTimestamp: handleSetTimestamp,
-        playPentagram: handlePlayPentagram
     }
 
     if (!item) return null
@@ -49,7 +45,6 @@ function PentagramSelect() {
         <>
             <PentagramSelectView 
                 item={item} 
-                timestamp={timestamp}
                 eventHandler={eventHandler}
             />
             <Outlet />


### PR DESCRIPTION
#### 1. usePentagramPlayer 훅
- `cleanup 함수` 미적용으로 인한 '재생 중' 여부 확인 정확도 저하 문제 해결
- '재생 중' 확인을 위한 `상태state` 추가
- state 갱신 순서를 재조정함으로써 현재 재생 시점과 펜타그램의 상태가 일치하지 않는 문제 해결
- `펜타그램 플레이어`의 작동 방식이 `호출 맥락`에 따라 달라지지 않을 것이 확실하므로 hooks를 내부에서 호출

#### 2. 미디어쿼리 브레이크포인트에 따른 css 변수 hooks 추가
- #24 
- 이후 `애니메이션` 및 `이벤트핸들러`를 위한 기능

#### 3. 작품 위치 node props 인터페이스 변경
- `각도angle`, `거리distance`를 따로 받는 구조에서 `위치position`으로 통합