### PR TITLE
feat: 펜타그램 플레이어 재생 애니메이션 추가(react-spring)

### DIFF
--- a/src/feature/Pentagram/components/PentagramCard/SelectMainPentagon/PentagramNode.tsx
+++ b/src/feature/Pentagram/components/PentagramCard/SelectMainPentagon/PentagramNode.tsx
@@ -1,5 +1,5 @@
 import type { MouseEventHandler } from 'react';
-import type { DBPentagramNodes, PentagramEventHandler } from '../../../types';
+import type { DBPentagramNodes, PentagramEventHandler, PentagramSelectOptions } from '../../../types';
 import type { OeuvreEventHandler } from '$feature/Oeuvre/types';
 import { getSnapshot, getUnionedChanges } from '../../../utils';
 import PositionAdjuster from '../../common/PositionAdjuster';
@@ -10,14 +10,16 @@ import "./style/pentagramNode.scss"
 type PentagramNodeProps = {
     item: DBPentagramNodes,
     timestamp: Date
+    options: PentagramSelectOptions
     eventHandler: PentagramEventHandler & OeuvreEventHandler
 }
 
 export default function PentagramNode(props: PentagramNodeProps) {
-    const { item, timestamp, eventHandler } = props
+    const { item, timestamp, options, eventHandler } = props
     const unionedChanges = getUnionedChanges(item)
     const { id, oeuvres } = item
-    const { angle, distance, deleted } = getSnapshot(unionedChanges, timestamp)
+    const position= getSnapshot(unionedChanges, timestamp)
+    const prevPosition = getSnapshot(unionedChanges, timestamp, true)
 
     const onClickNode: MouseEventHandler<HTMLDivElement> = (e) => {
         e.stopPropagation()
@@ -27,10 +29,13 @@ export default function PentagramNode(props: PentagramNodeProps) {
     return (
         <>
             {item && 
-            !deleted &&
-            typeof angle === 'number' &&
-            typeof distance === 'number' &&
-                <PositionAdjuster position={{angle, distance, deleted: false}}>
+            typeof position.angle === 'number' &&
+            typeof position.distance === 'number' &&
+                <PositionAdjuster 
+                    enableAnimation={options.enableAnimation}
+                    position={position}
+                    prevPosition={prevPosition}
+                >
                     <div
                         className="pentagram-node-component"
                         onClick={onClickNode}

--- a/src/feature/Pentagram/components/PentagramCard/SelectMainPentagon/index.tsx
+++ b/src/feature/Pentagram/components/PentagramCard/SelectMainPentagon/index.tsx
@@ -1,4 +1,4 @@
-import type { DBPentagram_SELECT, PentagramEventHandler } from "../../../types";
+import type { DBPentagram_SELECT, PentagramEventHandler, PentagramSelectOptions } from "../../../types";
 import OeuvrePentagonWrapper from "../../common/OeuvrePentagonWrapper";
 import PentagramNode from "./PentagramNode";
 
@@ -7,11 +7,12 @@ import './style/selectMainPentagon.scss'
 type SelectMainPentagonProps = {
     timestamp: Date,
     pentagram_nodesCollection: DBPentagram_SELECT["pentagram_nodesCollection"],
+    options: PentagramSelectOptions
     eventHandler: PentagramEventHandler
 }
 
 export default function SelectMainPentagon(props: SelectMainPentagonProps) {
-    const { timestamp, pentagram_nodesCollection, eventHandler } = props
+    const { timestamp, pentagram_nodesCollection, options, eventHandler } = props
     const items = pentagram_nodesCollection?.edges.map((edge) => edge.node)
 
     return pentagram_nodesCollection && (
@@ -21,6 +22,7 @@ export default function SelectMainPentagon(props: SelectMainPentagonProps) {
                     <PentagramNode 
                         key={item.id}
                         item={item}
+                        options={options}
                         eventHandler={eventHandler}
                         timestamp={timestamp}
                     />

--- a/src/feature/Pentagram/components/PentagramCard/index.tsx
+++ b/src/feature/Pentagram/components/PentagramCard/index.tsx
@@ -38,6 +38,7 @@ export default function PentagramCard(props: PentagramCardProps) {
                 {renderConfig.mainPentagon && 
                     <SelectMainPentagon 
                         timestamp={timestamp}
+                        options={options}
                         eventHandler={eventHandler}
                         pentagram_nodesCollection={pentagram_nodesCollection}
                     />

--- a/src/feature/Pentagram/components/common/PositionAdjuster.tsx
+++ b/src/feature/Pentagram/components/common/PositionAdjuster.tsx
@@ -1,35 +1,38 @@
-import type { CSSProperties, PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 import type { PentagramNodePosition } from '../../types';
+import { useSpring } from '@react-spring/web';
+import { useCSSVariables } from '$lib/hooks/useCSSVariables';
+import { animated } from '@react-spring/web';
+import { calcPositionAdjusterAnimation } from './animation';
 import './style/positionAdjuster.scss'
-
-interface NodeStyle extends CSSProperties {
-    '--distance-multiplier': number,
-    '--degrees': string
-}
 
 interface PositionAdjusterProps extends PropsWithChildren{
     position: PentagramNodePosition
+    prevPosition?: PentagramNodePosition
     behind?: boolean | null | undefined
+    enableAnimation?: boolean
 }
 
 export default function PositionAdjuster(props: PositionAdjusterProps) {
-    const { position, behind, ...restProps } = props
+    const { position, prevPosition, behind, enableAnimation, ...restProps } = props
+    const STYLE = useCSSVariables()
 
-    const style: NodeStyle = {
-        '--distance-multiplier': (position.distance || 0) / 100,
-        '--degrees': `${position.angle || 0}deg`
-    }
-
+    const positionAdjusterAnimation = calcPositionAdjusterAnimation({
+        position, prevPosition, enableAnimation, STYLE
+    })
+    
+    const springProps = useSpring(positionAdjusterAnimation)
+    
     return (
-        <div 
+        <animated.div
             {...restProps}
-            style={style}
+            style={springProps}
             className={[
                 "position-adjuster-component", 
                 behind ? "position-adjuster-component--behind" : ""
             ].join(" ")}
         >
             {props.children}
-        </div>
+        </animated.div>
     )
 }

--- a/src/feature/Pentagram/components/common/animation/index.ts
+++ b/src/feature/Pentagram/components/common/animation/index.ts
@@ -1,0 +1,1 @@
+export * from './positionAdjusterAnimation'

--- a/src/feature/Pentagram/components/common/animation/positionAdjusterAnimation.ts
+++ b/src/feature/Pentagram/components/common/animation/positionAdjusterAnimation.ts
@@ -1,0 +1,28 @@
+import type { PentagramNodePosition } from "../../../types"
+import { calcTransformValueFromPosition } from "../../../utils"
+import { useCSSVariables } from "$lib/hooks/useCSSVariables"
+
+export function calcPositionAdjusterAnimation(payload: {
+    position: PentagramNodePosition,
+    prevPosition?: PentagramNodePosition | undefined,
+    enableAnimation?: boolean,
+    STYLE: ReturnType<typeof useCSSVariables>
+}) {
+    const { position, prevPosition, enableAnimation, STYLE } = payload
+    const { transformX, transformY } = calcTransformValueFromPosition(position, STYLE)
+    const { transformX: prevX, transformY: prevY } = calcTransformValueFromPosition(prevPosition, STYLE)
+    const isValidCurPosition = typeof transformX === 'number' && typeof transformY === 'number'
+    const isValidPrevPosition = typeof prevX === 'number' && typeof prevY === 'number'
+
+    return {
+        from: { 
+            opacity: (!isValidPrevPosition || prevPosition?.deleted) ?  0 : 1,
+            transform: (enableAnimation && isValidPrevPosition) 
+                ? `translate(${prevX}px, ${prevY}px)` 
+                : `translate(${transformX}px, ${transformY}px)` 
+        },
+        opacity: (!isValidCurPosition || position.deleted) ?  0 : 1,
+        transform: `translate(${transformX}px, ${transformY}px)` 
+    }
+    
+}

--- a/src/feature/Pentagram/components/common/style/positionAdjuster.scss
+++ b/src/feature/Pentagram/components/common/style/positionAdjuster.scss
@@ -1,24 +1,13 @@
 @use "src/lib/style/variables";
 
 .position-adjuster-component {
-    --node: #{variables.$node_small}px;
-    @media only screen and (min-width: 500px) {
-        --node: #{variables.$node_medium}px;
-    };
-
     touch-action: none;
     -ms-touch-action: none;
-    
-    --radius: calc(var(--distance-multiplier) * var(--node) * 3);
-    --calibrated: calc(var(--degrees) + #{variables.$pentagon_angle_offset});
-    --transformX: calc(cos(var(--calibrated)) * var(--radius) - var(--node) * 0.5);
-    --transformY: calc(sin(var(--calibrated)) * var(--radius) - var(--node) * 0.5);
     position: absolute;
     border-radius: 50%;
-    transform: translate(var(--transformX), var(--transformY));
     background-color: rgb(var(--background-color));
     z-index: 2;
-
+      
     &.position-adjuster-component--behind {
         z-index: 1
     }

--- a/src/feature/Pentagram/types.ts
+++ b/src/feature/Pentagram/types.ts
@@ -9,7 +9,8 @@ export type DBPentagramRevisions = PentagramRevisionsMinimalInfoFragment
 
 export type PentagramSelectRenderConfig = ISlotRenderConfig<"metaInfo" | "mainPentagon" | "description" | "revision" | "player">
 export type PentagramSelectOptions = {
-    displayRevisionIds?: string[] | null | undefined
+    displayRevisionIds?: string[] | null | undefined,
+    enableAnimation?: boolean
 }
 
 export type PentagramEventHandler = {

--- a/src/feature/Pentagram/utils/animation/calcTransformValueFromPosition.ts
+++ b/src/feature/Pentagram/utils/animation/calcTransformValueFromPosition.ts
@@ -1,0 +1,25 @@
+import type { PentagramNodePosition } from "../../types"
+import { useCSSVariables } from "$lib/hooks/useCSSVariables"
+import { PENTAGRAM } from "../../constants"
+
+export function calcTransformValueFromPosition(
+    position: PentagramNodePosition | undefined, 
+    STYLE: ReturnType<typeof useCSSVariables>
+) {
+    if (
+        !position || 
+        typeof position.angle !== 'number' || 
+        typeof position.distance !== 'number'
+    ) {
+        return { transformX: null, transformY: null }
+    }
+    
+    const { angle, distance } = position
+    const radius = distance / 100 * STYLE.NODE * 3
+    const degreeWithOffset = (angle+STYLE.PENTAGON_ANGLE_OFFSET) * Math.PI / PENTAGRAM.HALF_CIRCLE
+
+    const transformX = Math.cos(degreeWithOffset) * radius - STYLE.NODE * 0.5
+    const transformY = Math.sin(degreeWithOffset) * radius - STYLE.NODE * 0.5
+
+    return { transformX, transformY }
+}

--- a/src/feature/Pentagram/utils/animation/index.ts
+++ b/src/feature/Pentagram/utils/animation/index.ts
@@ -1,0 +1,1 @@
+export * from './calcTransformValueFromPosition'

--- a/src/feature/Pentagram/utils/index.ts
+++ b/src/feature/Pentagram/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './animation'
 export * from './components'
 export * from './event'
 export * from './mutation'

--- a/src/feature/Profile/components/ProfileSelctView.tsx
+++ b/src/feature/Profile/components/ProfileSelctView.tsx
@@ -56,10 +56,12 @@ export default function ProfileSelectView(props: {
                     mainPentagon: true,
                     description: false,
                     revision: false,
-                    player: false
+                    player: true
                 }}
                 eventHandler={eventHandler}
-                options={{}}
+                options={{
+                    enableAnimation: true
+                }}
             />
         )) || []
     ), [eventHandler, item?.pentagramsCollection?.edges])

--- a/src/routes/_public/pentagram/$pentagramId/view.tsx
+++ b/src/routes/_public/pentagram/$pentagramId/view.tsx
@@ -46,6 +46,9 @@ function PentagramSelect() {
             <PentagramSelectView 
                 item={item} 
                 eventHandler={eventHandler}
+                options={{
+                    enableAnimation: true
+                }}
             />
             <Outlet />
         </>


### PR DESCRIPTION
#### 1. 재생 애니메이션
- #24, #28
- `transformX` 및 `transformY` 값을 구하는 함수 추가
- 이 값을 `react-spring`에서 사용 가능한 옵션으로 변환하는 함수 추가
- `react-spring`을 통한 애니메이션 적용