### PR TITLE
refactor: 작품 노드 컴포넌트로부터 작품 호버카드 분리

### DIFF
--- a/src/feature/Oeuvre/components/OeuvreNode.tsx
+++ b/src/feature/Oeuvre/components/OeuvreNode.tsx
@@ -1,57 +1,25 @@
-import type { DBOeuvre, OeuvreEventHandler } from "../types";
-import { useRef } from "react";
-import { useHover } from '$lib/hooks';
+import type { DBOeuvre } from "../types";
+import type { useHover } from '$lib/hooks';
 import BucketImage from "$lib/components/common/BucketImage";
 import FallbackIcon from "$lib/components/icons/FallbackIcon";
-import OeuvreInfoCard from "./common/OeuvreInfoCard";
-import HoverCard from "$feature/portal/components/HoverCard";
 
 import "./style/oeuvreNode.scss"
 
 type OeuvreNodeProps = {
     item: DBOeuvre
-    enableHover?: boolean | undefined
-    eventHandler: OeuvreEventHandler
+    hoverHook: ReturnType<typeof useHover>
 }
 
 export default function OeuvreNode(props: OeuvreNodeProps) {
-    const { item, enableHover, eventHandler } = props
-    const { status, handleMouseLeave, handleMouseOver } = useHover()
-    const ref = useRef<HTMLDivElement | null>(null)
-    const position = ref.current?.getBoundingClientRect()
+    const { item, hoverHook } = props
+    const { handleMouseOver, handleMouseLeave } = hoverHook
     
     return (
         <div
-            ref={ref}
             onMouseOver={handleMouseOver}
             onMouseLeave={handleMouseLeave}
             className="oeuvre-node-component"
         >
-            {enableHover &&
-                <HoverCard
-                    position={position}
-                    status={status}
-                    handleMouseOver={handleMouseOver}
-                    handleMouseLeave={handleMouseLeave} 
-                >
-                    <div className="oeuvre-node-component__hover-card-inner-container">
-                        <OeuvreInfoCard
-                            item={item}
-                            renderConfig={{
-                                coverImage: false,
-                                title: true,
-                                mainInfo: false,
-                                subInfo: false
-                            }}
-                            eventHandler={eventHandler}
-                            options={{
-                                enableSelect: true
-                            }}
-                        />
-                    </div>
-                </HoverCard>
-            }
-
             <div className="oeuvre-node-component__cover-container">
                 <BucketImage 
                     bucket="oeuvres"

--- a/src/feature/Oeuvre/components/OeuvreNodeHoverCard.tsx
+++ b/src/feature/Oeuvre/components/OeuvreNodeHoverCard.tsx
@@ -1,0 +1,52 @@
+import type { DBOeuvre, OeuvreEventHandler } from "../types";
+import type { useHover } from '$lib/hooks';
+import { useRef } from "react";
+import OeuvreInfoCard from "./common/OeuvreInfoCard";
+import HoverCard from "$feature/portal/components/HoverCard";
+
+import "./style/oeuvreNodeHoverCard.scss"
+
+type OeuvreNodeHoverCardProps = {
+    item: DBOeuvre
+    hoverHook: ReturnType<typeof useHover>
+    eventHandler: OeuvreEventHandler
+}
+
+export default function OeuvreNodeHoverCard(props: OeuvreNodeHoverCardProps) {
+    const { item, hoverHook, eventHandler } = props
+    const { status, handleMouseLeave, handleMouseOver } = hoverHook
+    const ref = useRef<HTMLDivElement | null>(null)
+    const position = ref.current?.getBoundingClientRect()
+    
+    return (
+        <div
+            ref={ref}
+            onMouseOver={handleMouseOver}
+            onMouseLeave={handleMouseLeave}
+            className="oeuvre-node-hover-card-component"
+        >
+            <HoverCard
+                position={position}
+                status={status}
+                handleMouseOver={handleMouseOver}
+                handleMouseLeave={handleMouseLeave} 
+            >
+                <div className="oeuvre-node-hover-card-component__hover-card-inner-container">
+                    <OeuvreInfoCard
+                        item={item}
+                        renderConfig={{
+                            coverImage: false,
+                            title: true,
+                            mainInfo: false,
+                            subInfo: false
+                        }}
+                        eventHandler={eventHandler}
+                        options={{
+                            enableSelect: true
+                        }}
+                    />
+                </div>
+            </HoverCard>
+        </div>
+    )
+}

--- a/src/feature/Oeuvre/components/style/oeuvreNode.scss
+++ b/src/feature/Oeuvre/components/style/oeuvreNode.scss
@@ -13,14 +13,3 @@
         object-fit: cover;
     }
 }
-
-.oeuvre-node-component__hover-card-inner-container {
-    --node: #{variables.$node_small}px;
-    --base-size: 0.5rem;
-    @include box-shadow-2(rgb(var(--font-color)));
-    @include wide-hovercard(var(--node));
-    @media only screen and (min-width: 500px) {
-        --node: #{variables.$node_medium}px;
-        --base-size: 1rem;
-    }
-}

--- a/src/feature/Oeuvre/components/style/oeuvreNodeHoverCard.scss
+++ b/src/feature/Oeuvre/components/style/oeuvreNodeHoverCard.scss
@@ -1,0 +1,21 @@
+@use "src/lib/style/variables";
+@import "src/lib/style/atomicMixin";
+@import "src/lib/style/mixin";
+
+
+.oeuvre-node-hover-card-component {
+    position: absolute;
+    left: 0;
+    top:0;
+}
+
+.oeuvre-node-hover-card-component__hover-card-inner-container {
+    --node: #{variables.$node_small}px;
+    --base-size: 0.5rem;
+    @include box-shadow-2(rgb(var(--font-color)));
+    @include wide-hovercard(var(--node));
+    @media only screen and (min-width: 500px) {
+        --node: #{variables.$node_medium}px;
+        --base-size: 1rem;
+    }
+}

--- a/src/feature/Pentagram/components/PentagramCard/SelectMainPentagon/PentagramNode.tsx
+++ b/src/feature/Pentagram/components/PentagramCard/SelectMainPentagon/PentagramNode.tsx
@@ -1,9 +1,11 @@
 import type { MouseEventHandler } from 'react';
 import type { DBPentagramNodes, PentagramEventHandler, PentagramSelectOptions } from '../../../types';
 import type { OeuvreEventHandler } from '$feature/Oeuvre/types';
+import { useHover } from '$lib/hooks';
 import { getSnapshot, getUnionedChanges } from '../../../utils';
 import PositionAdjuster from '../../common/PositionAdjuster';
 import OeuvreNode from '$feature/Oeuvre/components/OeuvreNode';
+import OeuvreNodeHoverCard from '$feature/Oeuvre/components/OeuvreNodeHoverCard';
 
 import "./style/pentagramNode.scss"
 
@@ -16,6 +18,8 @@ type PentagramNodeProps = {
 
 export default function PentagramNode(props: PentagramNodeProps) {
     const { item, timestamp, options, eventHandler } = props
+    const hoverHook = useHover()
+
     const unionedChanges = getUnionedChanges(item)
     const { id, oeuvres } = item
     const position= getSnapshot(unionedChanges, timestamp)
@@ -40,7 +44,8 @@ export default function PentagramNode(props: PentagramNodeProps) {
                         className="pentagram-node-component"
                         onClick={onClickNode}
                     >
-                        <OeuvreNode item={oeuvres} enableHover={true} eventHandler={eventHandler} />
+                        <OeuvreNode item={oeuvres} hoverHook={hoverHook} />
+                        <OeuvreNodeHoverCard item={oeuvres} hoverHook={hoverHook} eventHandler={eventHandler} />
                     </div>
                 </PositionAdjuster>
             }

--- a/src/feature/Pentagram/components/PentagramUpsertView/PentagramUpsertEditor/UpdateMainPentagon/MergedNode.tsx
+++ b/src/feature/Pentagram/components/PentagramUpsertView/PentagramUpsertEditor/UpdateMainPentagon/MergedNode.tsx
@@ -1,8 +1,10 @@
 import type { DragEvent, MouseEvent, TouchEvent } from 'react';
 import type { OeuvreEventHandler } from '$feature/Oeuvre/types';
 import type { IMergedNode } from '../../../../store/pentagramUpsertSlice/interface';
+import { useHover } from '$lib/hooks';
 import PositionAdjuster from '../../../common/PositionAdjuster';
 import OeuvreNode from '$feature/Oeuvre/components/OeuvreNode';
+import OeuvreNodeHoverCard from '$feature/Oeuvre/components/OeuvreNodeHoverCard';
 
 import "./style/mergedNode.scss"
 
@@ -17,6 +19,7 @@ type MergedNodeProps = {
 export default function MergedNode(props: MergedNodeProps) {
     const { item, handleClickNode, handleClickSelectedNode, handleDragAndTouchMove, eventHandler } = props
     const { id, angle, distance, oeuvres, selected, deleted } = item
+    const hoverHook = useHover()
 
     const onClickNode = (e: MouseEvent<HTMLDivElement>) => {
         e.stopPropagation()
@@ -43,7 +46,7 @@ export default function MergedNode(props: MergedNodeProps) {
     return (
         <>
             {item &&
-                <PositionAdjuster behind={deleted} position={{ angle, distance, deleted }}>
+                <PositionAdjuster shadowDeleted={deleted} position={{ angle, distance, deleted }}>
                     <div
                         className={className}
                         // selecte node event
@@ -55,7 +58,8 @@ export default function MergedNode(props: MergedNodeProps) {
                         onDragStart={onDragStart}
                         onDragOver={(e) => e.preventDefault()}
                     >
-                        <OeuvreNode item={oeuvres} enableHover={!selected} eventHandler={eventHandler} />
+                        <OeuvreNode item={oeuvres} hoverHook={hoverHook} />
+                        <OeuvreNodeHoverCard item={oeuvres} hoverHook={hoverHook} eventHandler={eventHandler} />
                     </div>
                 </PositionAdjuster>
             }


### PR DESCRIPTION
#### 1. 호버카드 분리
- 기존에는 작품 노드 자체에 호버카드가 붙어 있었음
- 분리할 경우, hooks를 상위에서 호출한 뒤, `props`로 내려줘야 하므로 복잡해짐
    - 하지만 애니메이션을 위해 `조건부 렌더링` 활용이 제한됨에 따라 상황 변화
    - 당장 반드시 필요하진 않지만 이후의 유연성을 위해 분리
- 기능적으로도 분리된 기능이고 `작품 노드` 컴포넌트에 두 가지 기능을 위임하는 것임