### PR TITLE
refactor: 위치 조정 컴포넌트 애니메이션 및 속성 변경

### DIFF
--- a/src/feature/Pentagram/components/common/PositionAdjuster.tsx
+++ b/src/feature/Pentagram/components/common/PositionAdjuster.tsx
@@ -17,10 +17,7 @@ export default function PositionAdjuster(props: PositionAdjusterProps) {
     const { position, prevPosition, enableAnimation, shadowDeleted, ...restProps } = props
     const STYLE = useCSSVariables()
 
-    const positionAdjusterAnimation = calcPositionAdjusterAnimation({
-        position, prevPosition, enableAnimation, STYLE
-    })
-    
+    const positionAdjusterAnimation = calcPositionAdjusterAnimation({ position, prevPosition, enableAnimation, shadowDeleted, STYLE })
     const springProps = useSpring(positionAdjusterAnimation)
     
     return (

--- a/src/feature/Pentagram/components/common/animation/positionAdjusterAnimation.ts
+++ b/src/feature/Pentagram/components/common/animation/positionAdjusterAnimation.ts
@@ -1,28 +1,42 @@
 import type { PentagramNodePosition } from "../../../types"
+import type { useCSSVariables } from "$lib/hooks/useCSSVariables"
 import { calcTransformValueFromPosition } from "../../../utils"
-import { useCSSVariables } from "$lib/hooks/useCSSVariables"
+
+// COMMENT
+// from 부분은 신규 생성 노드의 애니메이션을 위해 필요
 
 export function calcPositionAdjusterAnimation(payload: {
     position: PentagramNodePosition,
     prevPosition?: PentagramNodePosition | undefined,
     enableAnimation?: boolean,
+    shadowDeleted?: boolean | null | undefined
     STYLE: ReturnType<typeof useCSSVariables>
 }) {
-    const { position, prevPosition, enableAnimation, STYLE } = payload
+    const { position, prevPosition, enableAnimation, shadowDeleted, STYLE } = payload
     const { transformX, transformY } = calcTransformValueFromPosition(position, STYLE)
     const { transformX: prevX, transformY: prevY } = calcTransformValueFromPosition(prevPosition, STYLE)
     const isValidCurPosition = typeof transformX === 'number' && typeof transformY === 'number'
     const isValidPrevPosition = typeof prevX === 'number' && typeof prevY === 'number'
 
+    const fromScale = (!isValidPrevPosition || prevPosition?.deleted) ? 0 : 1
+    const fromTranslate = (enableAnimation && isValidPrevPosition)
+        ? `${prevX}px, ${prevY}px`
+        : `${transformX}px, ${transformY}px` 
+
+    const toScale = shadowDeleted ? 1
+        : (!isValidCurPosition || position.deleted) ?  0 
+        : 1
+    const toTranslate = `${transformX}px, ${transformY}px`
+
     return {
         from: { 
-            opacity: (!isValidPrevPosition || prevPosition?.deleted) ?  0 : 1,
-            transform: (enableAnimation && isValidPrevPosition) 
-                ? `translate(${prevX}px, ${prevY}px)` 
-                : `translate(${transformX}px, ${transformY}px)` 
+            transform: `translate(${fromTranslate}) scale(${fromScale})`
         },
-        opacity: (!isValidCurPosition || position.deleted) ?  0 : 1,
-        transform: `translate(${transformX}px, ${transformY}px)` 
+        transform: `translate(${toTranslate}) scale(${toScale})`,
+        config: { 
+            mass: 3,
+            friction: 40,
+            tension: 280,
+        }
     }
-    
 }

--- a/src/feature/Pentagram/components/common/style/positionAdjuster.scss
+++ b/src/feature/Pentagram/components/common/style/positionAdjuster.scss
@@ -8,7 +8,7 @@
     background-color: rgb(var(--background-color));
     z-index: 2;
       
-    &.position-adjuster-component--behind {
+    &.position-adjuster-component--shadowDeleted {
         z-index: 1
     }
 }


### PR DESCRIPTION
#### 1. 위치 조정 컴포넌트 애니메이션 설정 변경 
- 투명도에서 scale로 변경
    - 투명도 애니메이션 사용 시, 이후 추가적인 imperative 처리 필요
    - 투명하더라도 호버 이벤트 및 클릭 이벤트가 가능하므로 이를 비활성화 처리를 해야 함
- 삭제된 노드 조건부로 보이게 설정
    - 삭제된 노드도 수정 상황에서는 보여야 함(복원 목적)