### PR TITLE
feat: 피드의 펜타그램 Viewport에 진입 시 애니메이션 실행 기능 추가

### DIFF
--- a/src/feature/Pentagram/components/PentagramCard/SelectMainPentagon/PentagramNode.tsx
+++ b/src/feature/Pentagram/components/PentagramCard/SelectMainPentagon/PentagramNode.tsx
@@ -11,13 +11,14 @@ import "./style/pentagramNode.scss"
 
 type PentagramNodeProps = {
     item: DBPentagramNodes,
+    inView: boolean
     timestamp: Date
     options: PentagramSelectOptions
     eventHandler: PentagramEventHandler & OeuvreEventHandler
 }
 
 export default function PentagramNode(props: PentagramNodeProps) {
-    const { item, timestamp, options, eventHandler } = props
+    const { item, inView, timestamp, options, eventHandler } = props
     const hoverHook = useHover()
 
     const unionedChanges = getUnionedChanges(item)
@@ -36,6 +37,7 @@ export default function PentagramNode(props: PentagramNodeProps) {
             typeof position.angle === 'number' &&
             typeof position.distance === 'number' &&
                 <PositionAdjuster 
+                    inView={inView}
                     enableAnimation={options.enableAnimation}
                     position={position}
                     prevPosition={prevPosition}

--- a/src/feature/Pentagram/components/PentagramCard/SelectMainPentagon/index.tsx
+++ b/src/feature/Pentagram/components/PentagramCard/SelectMainPentagon/index.tsx
@@ -1,4 +1,6 @@
 import type { DBPentagram_SELECT, PentagramEventHandler, PentagramSelectOptions } from "../../../types";
+import { useIntersectionObserver } from "$lib/hooks";
+import { useRef, useState } from "react";
 import OeuvrePentagonWrapper from "../../common/OeuvrePentagonWrapper";
 import PentagramNode from "./PentagramNode";
 
@@ -14,6 +16,11 @@ type SelectMainPentagonProps = {
 export default function SelectMainPentagon(props: SelectMainPentagonProps) {
     const { timestamp, pentagram_nodesCollection, options, eventHandler } = props
     const items = pentagram_nodesCollection?.edges.map((edge) => edge.node)
+    const sentinelRef = useRef<HTMLDivElement | null>(null)
+    const [inView, setInView] = useState(false)
+    
+    const onIntersect = () => setInView(true)
+    useIntersectionObserver(sentinelRef, onIntersect)
 
     return pentagram_nodesCollection && (
         <div className="select-main-pentagon-component">
@@ -21,6 +28,7 @@ export default function SelectMainPentagon(props: SelectMainPentagonProps) {
                 {items?.map((item) => (
                     <PentagramNode 
                         key={item.id}
+                        inView={inView}
                         item={item}
                         options={options}
                         eventHandler={eventHandler}
@@ -28,6 +36,7 @@ export default function SelectMainPentagon(props: SelectMainPentagonProps) {
                     />
                 ))}
             </OeuvrePentagonWrapper>
+            {!inView && <div ref={sentinelRef} className="select-main-pentagon-component__sentinel" />}
         </div>
     )
 }

--- a/src/feature/Pentagram/components/PentagramCard/SelectMainPentagon/style/selectMainPentagon.scss
+++ b/src/feature/Pentagram/components/PentagramCard/SelectMainPentagon/style/selectMainPentagon.scss
@@ -2,5 +2,11 @@
 
 .select-main-pentagon-component {
     @include flex;
+    @include flex-col;
     @include flex-center;
+
+    .select-main-pentagon-component__sentinel {
+        width: 0px;
+        height: 0px;
+    }
 }

--- a/src/feature/Pentagram/components/PentagramUpsertView/PentagramUpsertEditor/UpdateMainPentagon/MergedNode.tsx
+++ b/src/feature/Pentagram/components/PentagramUpsertView/PentagramUpsertEditor/UpdateMainPentagon/MergedNode.tsx
@@ -46,7 +46,7 @@ export default function MergedNode(props: MergedNodeProps) {
     return (
         <>
             {item &&
-                <PositionAdjuster shadowDeleted={deleted} position={{ angle, distance, deleted }}>
+                <PositionAdjuster shadowDeleted={deleted} inView={true} position={{ angle, distance, deleted }}>
                     <div
                         className={className}
                         // selecte node event

--- a/src/feature/Pentagram/components/PentagramUpsertView/PentagramUpsertEditor/UpdateMainPentagon/SelectedPosition.tsx
+++ b/src/feature/Pentagram/components/PentagramUpsertView/PentagramUpsertEditor/UpdateMainPentagon/SelectedPosition.tsx
@@ -34,7 +34,7 @@ export default function SelectedPosition(props: SelectedPositionProps) {
             {
                 typeof angle === 'number' && 
                 typeof distance === 'number' &&
-                <PositionAdjuster position={{ angle, distance, deleted: false }}>
+                <PositionAdjuster inView={true} position={{ angle, distance, deleted: false }}>
                     <div 
                         onClick={onClickSelectedPosition}
                         draggable={true}

--- a/src/feature/Pentagram/components/common/PositionAdjuster.tsx
+++ b/src/feature/Pentagram/components/common/PositionAdjuster.tsx
@@ -9,17 +9,25 @@ import './style/positionAdjuster.scss'
 interface PositionAdjusterProps extends PropsWithChildren{
     position: PentagramNodePosition
     prevPosition?: PentagramNodePosition
+    inView: boolean
     enableAnimation?: boolean
     shadowDeleted?: boolean | null | undefined
 }
 
 export default function PositionAdjuster(props: PositionAdjusterProps) {
-    const { position, prevPosition, enableAnimation, shadowDeleted, ...restProps } = props
+    const { position, prevPosition, inView, enableAnimation, shadowDeleted, ...restProps } = props
     const STYLE = useCSSVariables()
 
-    const positionAdjusterAnimation = calcPositionAdjusterAnimation({ position, prevPosition, enableAnimation, shadowDeleted, STYLE })
+    const positionAdjusterAnimation = calcPositionAdjusterAnimation({ 
+        position, 
+        prevPosition, 
+        inView,
+        enableAnimation, 
+        shadowDeleted, 
+        STYLE 
+    })
     const springProps = useSpring(positionAdjusterAnimation)
-    
+
     return (
         <animated.div
             {...restProps}

--- a/src/feature/Pentagram/components/common/animation/positionAdjusterAnimation.ts
+++ b/src/feature/Pentagram/components/common/animation/positionAdjusterAnimation.ts
@@ -8,25 +8,28 @@ import { calcTransformValueFromPosition } from "../../../utils"
 export function calcPositionAdjusterAnimation(payload: {
     position: PentagramNodePosition,
     prevPosition?: PentagramNodePosition | undefined,
+    inView: boolean,
     enableAnimation?: boolean,
     shadowDeleted?: boolean | null | undefined
     STYLE: ReturnType<typeof useCSSVariables>
 }) {
-    const { position, prevPosition, enableAnimation, shadowDeleted, STYLE } = payload
+    const { position, prevPosition, inView, enableAnimation, shadowDeleted, STYLE } = payload
     const { transformX, transformY } = calcTransformValueFromPosition(position, STYLE)
     const { transformX: prevX, transformY: prevY } = calcTransformValueFromPosition(prevPosition, STYLE)
     const isValidCurPosition = typeof transformX === 'number' && typeof transformY === 'number'
     const isValidPrevPosition = typeof prevX === 'number' && typeof prevY === 'number'
 
-    const fromScale = (!isValidPrevPosition || prevPosition?.deleted) ? 0 : 1
-    const fromTranslate = (enableAnimation && isValidPrevPosition)
-        ? `${prevX}px, ${prevY}px`
-        : `${transformX}px, ${transformY}px` 
+    const prevTranslate = `${prevX}px, ${prevY}px`
+    const curTranslate = `${transformX}px, ${transformY}px` 
+
+    const fromScale = isValidPrevPosition && !prevPosition?.deleted ? 1 : 0
+    const fromTranslate = (enableAnimation && isValidPrevPosition) ? prevTranslate : curTranslate
 
     const toScale = shadowDeleted ? 1
-        : (!isValidCurPosition || position.deleted) ?  0 
-        : 1
-    const toTranslate = `${transformX}px, ${transformY}px`
+        : !inView ? fromScale
+        : isValidCurPosition && !position.deleted ?  1 
+        : 0
+    const toTranslate = (enableAnimation && isValidPrevPosition && !inView) ? prevTranslate : curTranslate
 
     return {
         from: { 

--- a/src/feature/Pentagram/utils/components/getSnapshot.ts
+++ b/src/feature/Pentagram/utils/components/getSnapshot.ts
@@ -21,7 +21,9 @@ export function getSnapshot(
         .find((change) => {
             if (!change) return false
             if (!change?.created_at) return false
-            if (new Date(change?.created_at) > timestamp) return false
+            const date = new Date(change?.created_at)
+            if (date > timestamp) return false
+            if (calcBeforePosition && date >= timestamp) return false
             return true
         })
         ?.changeType === 'remove'

--- a/src/feature/feed/components/FeedItem.tsx
+++ b/src/feature/feed/components/FeedItem.tsx
@@ -36,7 +36,8 @@ export default function FeedItem(props: FeedItemProps) {
                 }}
                 options={{
                     displayRevisionIds: [id],
-                    forcedTimestamp: new Date(item.created_at)
+                    forcedTimestamp: new Date(item.created_at),
+                    enableAnimation: true
                 }}
                 eventHandler={eventHandler}
             />

--- a/src/lib/components/common/InfiniteScrollTrigger.tsx
+++ b/src/lib/components/common/InfiniteScrollTrigger.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef } from "react"
+import { useRef } from "react"
+import { useIntersectionObserver } from "$lib/hooks"
 import LoadingSpinner from "./LoadingSpinner"
 import "./style/infiniteScrollTrigger.scss"
 
@@ -9,41 +10,13 @@ type LoadMoreProps = {
 
 export default function InfiniteScrollTrigger(props: LoadMoreProps) {
     const { handleLoadMore, hasNextPage } = props
+
+    const onIntersect = () => {
+       hasNextPage && handleLoadMore()
+    }
+
 	const sentinelRef = useRef<HTMLDivElement>(null);
-	const observerRef = useRef<IntersectionObserver | null>(null);
-    
-
-    const handleIntersect = useCallback((entries: IntersectionObserverEntry[]) => {
-        if (entries[0].isIntersecting && hasNextPage) {
-            handleLoadMore()
-        }
-    }, [hasNextPage, handleLoadMore])
-
-	useEffect(() => {
-		observerRef.current = new IntersectionObserver(handleIntersect, {
-			root: null,
-			rootMargin: "0px",
-			threshold: 0,
-		});
-
-		if (sentinelRef.current) {
-			observerRef.current.observe(sentinelRef.current)
-		}
-
-		return () => {
-			if (observerRef.current) {
-				observerRef.current.disconnect()
-			}
-		}
-	}, [handleIntersect]);
-
-    useEffect(() => {
-		if (observerRef.current && sentinelRef.current) {
-			observerRef.current.disconnect();
-			observerRef.current.observe(sentinelRef.current);
-		}
-	}, [hasNextPage]);
-
+    useIntersectionObserver(sentinelRef, onIntersect)
 
     return (
         <div className="infinite-scroll-trigger-component">

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './useHover'
 export * from './useTranslatedRelativeTime'
+export * from './useIntersectionObserver'
 export * from './useThrottle'
 export * from './toaster'

--- a/src/lib/hooks/useIntersectionObserver.ts
+++ b/src/lib/hooks/useIntersectionObserver.ts
@@ -1,0 +1,37 @@
+import type { RefObject } from "react"
+import { useCallback, useEffect, useRef } from "react";
+
+export function useIntersectionObserver(
+    sentinelRef: RefObject<HTMLDivElement>,
+    cb: () => void
+) {
+	const observerRef = useRef<IntersectionObserver | null>(null);
+    const handleIntersect = useCallback((entries: IntersectionObserverEntry[]) => {
+        if (entries[0].isIntersecting && cb) cb()
+    }, [cb])
+
+    useEffect(() => {
+        observerRef.current = new IntersectionObserver(handleIntersect, {
+            root: null,
+            rootMargin: "0px",
+            threshold: 0,
+        });
+
+        if (sentinelRef.current) {
+            observerRef.current.observe(sentinelRef.current)
+		}
+
+        return () => {
+            if (observerRef.current) {
+                observerRef.current.disconnect()
+            }
+        }
+    }, [handleIntersect, sentinelRef]);
+
+    useEffect(() => {
+        if (observerRef.current && sentinelRef.current) {
+            observerRef.current.disconnect();
+            observerRef.current.observe(sentinelRef.current);
+        }
+    }, [sentinelRef]);
+}


### PR DESCRIPTION
#### 1. IntersectionObserver hooks 분리
- 기존 무한스크롤 용도의 hooks를 분리
- 인터섹션이 발생했는지를 기준으로 애니메이션 재생하기 위함
- 모든 펜타그램 컴포넌트에서 호출되는 hooks로 메모리 누수 관리 필요