### PR TITLE
refactor: CSS 변수 모듈화 및 필요 함수에 변수 전달 

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsr generate && tsc && vite build",
     "update-types": "npx supabase gen types typescript --project-id \"$SUPABASE_PROJECT_ID\" > src/lib/types/supabase.ts",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "generate": "graphql-codegen"
+    "generate": "graphql-codegen",
+    "css-module-type-gen": "pnpm typed-scss-modules src/lib/style/_variables.module.scss"
   },
   "dependencies": {
     "@apollo/client": "^3.8.10",

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,4 +1,5 @@
 @import "src/lib/style/mixin";
+@import "src/lib/style/variables.module";
 @import url("https://cdn.jsdelivr.net/gh/wanteddev/wanted-sans@v1.0.1/packages/wanted-sans/fonts/webfonts/variable/split/WantedSansVariable.min.css");
 
 body {
@@ -31,29 +32,3 @@ textarea {
     color: inherit;
 }
 
-:root {
-    --font-color: 255, 255, 255;
-    --weak-font-color: 168, 168, 168;
-
-    // 배경 밝기에 따른 적응형 색상 변수
-    --light-font-color: 240, 240, 240;
-    --dark-font-color: 16, 16, 16;
-
-    --background-color: 24, 28, 24;
-    --modal-background: 36, 36, 36;
-    --modal-backdrop: 12, 12, 12;
-
-    --dark-gray: 51, 51, 51;
-    --true-gray: 128, 128, 128;
-
-    --primary: 43, 166, 137;
-    --info: 0, 167, 195;
-    --success: 0, 188, 93;
-    --warning: 243, 133, 0;
-    --danger: 255, 69, 58;
-
-    --base-size: 1rem;
-    color: rgb(var(--font-color));
-    background-color: rgb(var(--background-color));
-    font-family: "Wanted Sans Variable";
-}

--- a/src/feature/Oeuvre/components/style/oeuvreNode.scss
+++ b/src/feature/Oeuvre/components/style/oeuvreNode.scss
@@ -1,4 +1,3 @@
-@use "src/lib/style/variables";
 @import "src/lib/style/atomicMixin";
 @import "src/lib/style/mixin";
 

--- a/src/feature/Oeuvre/components/style/oeuvreNodeHoverCard.scss
+++ b/src/feature/Oeuvre/components/style/oeuvreNodeHoverCard.scss
@@ -1,4 +1,4 @@
-@use "src/lib/style/variables";
+@use "src/lib/style/variables.module";
 @import "src/lib/style/atomicMixin";
 @import "src/lib/style/mixin";
 
@@ -10,12 +10,10 @@
 }
 
 .oeuvre-node-hover-card-component__hover-card-inner-container {
-    --node: #{variables.$node_small}px;
     --base-size: 0.5rem;
     @include box-shadow-2(rgb(var(--font-color)));
     @include wide-hovercard(var(--node));
     @media only screen and (min-width: 500px) {
-        --node: #{variables.$node_medium}px;
         --base-size: 1rem;
     }
 }

--- a/src/feature/Pentagram/components/common/style/oeuvrePentagonWrapper.scss
+++ b/src/feature/Pentagram/components/common/style/oeuvrePentagonWrapper.scss
@@ -1,28 +1,25 @@
-@use "src/lib/style/variables";
+@import "src/lib/style/variables.module";
 @import "src/lib/style/atomicMixin";
 
 .oeuvre-pentagon-wrapper-component {
     @include flex;
-    --node: #{variables.$node_small}px;
-    @media only screen and (min-width: 500px) {
-        --node: #{variables.$node_medium}px;
-    }
-    width: calc(var(--node) * 8);
-    height: calc(var(--node) * 8);
+    --outer-size: calc(var(--node) * var(--pentagon-outer-container-multiplier));
+    width: var(--outer-size);
+    height: var(--outer-size);
 
     .oeuvre-pentagon-wrapper-component__parent {
         position: relative;
         width: 0px;
-        height:calc(var(--node) * 3); // CSS BALCK MAGIC 반응형으로 넘기는 부모 요소의 '반지름'이 달라지는 부분 해결
+        height: 0px;
         left: 50%;
         top: 50%;
 
         .oeuvre-pentagon-wrapper-component__pentagon {
             @include stroke-sm(rgb(var(--font-color)));
             @include fill-sm(none);
-            --size: calc(var(--node) * 7.5);
-            width: var(--size);
-            height: var(--size);
+            --pentagon-size: calc(var(--node) * var(--pentagon-inner-component-multiplier));
+            width: var(--pentagon-size);
+            height: var(--pentagon-size);
             transform: translate(-50%, -53%);
         }
     }

--- a/src/feature/Pentagram/components/common/style/positionAdjuster.scss
+++ b/src/feature/Pentagram/components/common/style/positionAdjuster.scss
@@ -1,5 +1,3 @@
-@use "src/lib/style/variables";
-
 .position-adjuster-component {
     touch-action: none;
     -ms-touch-action: none;
@@ -7,7 +5,7 @@
     border-radius: 50%;
     background-color: rgb(var(--background-color));
     z-index: 2;
-      
+
     &.position-adjuster-component--shadowDeleted {
         z-index: 1
     }

--- a/src/feature/Pentagram/hooks/eventHandler/update/useMainPentagonEventHandler.ts
+++ b/src/feature/Pentagram/hooks/eventHandler/update/useMainPentagonEventHandler.ts
@@ -1,5 +1,6 @@
 import type { MouseEvent, MutableRefObject, TouchEvent } from "react"
 import type { QuadtreeNode } from "../../../utils"
+import type { useCSSVariables } from "$lib/hooks/useCSSVariables";
 
 import { useDispatch } from "react-redux"
 import { useInsertSelectedInQuadtree } from '../..';
@@ -8,7 +9,8 @@ import { checkCollidingOrThrow, getAngleAndDisctanceOrThrow } from '../../../uti
 
 export function useMainPentagonEventHandler(
     parentRef: MutableRefObject<HTMLDivElement | null>, 
-    quadtreeRef: MutableRefObject<QuadtreeNode | null>
+    quadtreeRef: MutableRefObject<QuadtreeNode | null>,
+    STYLE: ReturnType<typeof useCSSVariables>
 ) {
     const dispatch = useDispatch()
     const insertSelected = useInsertSelectedInQuadtree(quadtreeRef)
@@ -19,7 +21,7 @@ export function useMainPentagonEventHandler(
 
     const handleSetNewPosition = (e: MouseEvent<HTMLDivElement>) => {
         insertSelected();
-        const { angle, distance } = getAngleAndDisctanceOrThrow(e, parentRef.current)
+        const { angle, distance } = getAngleAndDisctanceOrThrow(e, parentRef.current, undefined, STYLE)
         checkCollidingOrThrow({ angle, distance }, quadtreeRef.current)
 
         dispatch(unselectSelected())
@@ -29,7 +31,7 @@ export function useMainPentagonEventHandler(
     const handleDragAndTouchMove = (e: MouseEvent<HTMLDivElement> | TouchEvent<HTMLDivElement>) => {       
         const target = ("touches" in e) ? e.touches[0] : e 
 
-        const { angle, distance } = getAngleAndDisctanceOrThrow(target, parentRef.current)
+        const { angle, distance } = getAngleAndDisctanceOrThrow(target, parentRef.current, undefined, STYLE)
         checkCollidingOrThrow({ angle, distance }, quadtreeRef.current)
     
         dispatch(setPosition({ angle, distance }))

--- a/src/feature/Pentagram/utils/animation/calcTransformValueFromPosition.ts
+++ b/src/feature/Pentagram/utils/animation/calcTransformValueFromPosition.ts
@@ -13,13 +13,13 @@ export function calcTransformValueFromPosition(
     ) {
         return { transformX: null, transformY: null }
     }
-    
-    const { angle, distance } = position
-    const radius = distance / 100 * STYLE.NODE * 3
-    const degreeWithOffset = (angle+STYLE.PENTAGON_ANGLE_OFFSET) * Math.PI / PENTAGRAM.HALF_CIRCLE
 
-    const transformX = Math.cos(degreeWithOffset) * radius - STYLE.NODE * 0.5
-    const transformY = Math.sin(degreeWithOffset) * radius - STYLE.NODE * 0.5
+    const { angle, distance } = position
+    const radius = distance / 100 * Number(STYLE.node) * 3
+    const degreeWithOffset = (angle+Number(STYLE.pentagonAngleOffset)) * Math.PI / Number(PENTAGRAM.HALF_CIRCLE)
+
+    const transformX = Math.cos(degreeWithOffset) * radius - Number(STYLE.node) * 0.5
+    const transformY = Math.sin(degreeWithOffset) * radius - Number(STYLE.node) * 0.5
 
     return { transformX, transformY }
 }

--- a/src/feature/Pentagram/utils/event/getAngleAndDisctanceOrThrow.ts
+++ b/src/feature/Pentagram/utils/event/getAngleAndDisctanceOrThrow.ts
@@ -1,17 +1,20 @@
+import type { useCSSVariables } from "$lib/hooks/useCSSVariables"
 import { PositionError } from "../../error"
 import { PENTAGRAM } from "../../constants"
 
 export function getAngleAndDisctanceOrThrow(
     event: {clientX: number, clientY: number}, 
     parentElem: HTMLDivElement | null, 
-    sides: number=PENTAGRAM.SIDES
+    sides: number=PENTAGRAM.SIDES,
+    STYLE: ReturnType<typeof useCSSVariables>
 ) {
     if (!parentElem) throw new PositionError()
     const rect = parentElem.getBoundingClientRect()
+
     const x = event.clientX - rect.left 
     const y = event.clientY - rect.top
 
-    const radius = rect.height // TODO 반응형으로 radius가 바뀌기 때문에 불가피하게 넣은 흑마술임 다른 방법을 고안할 필요가 있음
+    const radius = Number(STYLE.node) * Number(STYLE.pentagonRadiusMultiplier)
 
     if (!isInside(y, x, radius, sides)) throw new PositionError()
 

--- a/src/feature/template/components/style/infoCard.scss
+++ b/src/feature/template/components/style/infoCard.scss
@@ -1,8 +1,7 @@
-@use "src/lib/style/variables";
+@import "src/lib/style/variables.module";
 @import "src/lib/style/atomicMixin";
 
 .info-card-template {
-    --node: #{variables.$node_small}px;
     @include flex-col;
     flex-grow: 1;
     @media only screen and (min-width: 500px) {
@@ -49,10 +48,11 @@
         }
 
         &.info-card-template__cover-container--mini {
-            min-width: var(--node);
-            max-width: var(--node);
-            min-height: var(--node);
-            max-height: var(--node);
+            --cover-size: calc(var(--node-small) * 1px);
+            min-width: var(--cover-size);
+            max-width: var(--cover-size);
+            min-height: var(--cover-size);
+            max-height: var(--cover-size);
         }
 
         // COMMENT 다른 계층 구조에서 사용되는 선택자임을 주의

--- a/src/lib/hooks/useCSSVariables.ts
+++ b/src/lib/hooks/useCSSVariables.ts
@@ -2,25 +2,25 @@ import { useMediaQuery } from "usehooks-ts";
 import { STYLE } from "$lib/style/variables";
 
 export function useCSSVariables() {
-    const lg = useMediaQuery(`only screen and (min-width : ${STYLE.BREAK_POINT.MD}px)`);
-    const md = useMediaQuery(`only screen and (min-width : ${STYLE.BREAK_POINT.SM}px)`);
+    const lg = useMediaQuery(`only screen and (min-width : ${STYLE.breakPoint.md}px)`);
+    const md = useMediaQuery(`only screen and (min-width : ${STYLE.breakPoint.sm}px)`);
 
     if (lg) {
         return {
-            ...STYLE.COMMON,
-            ...STYLE.LG
+            ...STYLE.common,
+            ...STYLE.lg
         }
     }
 
     if (md) {
         return {
-            ...STYLE.COMMON,
-            ...STYLE.MD
+            ...STYLE.common,
+            ...STYLE.md
         }
     }
 
     return {
-        ...STYLE.COMMON,
-        ...STYLE.SM
+        ...STYLE.common,
+        ...STYLE.sm
     }
 }

--- a/src/lib/style/_mainPentagonMixin.scss
+++ b/src/lib/style/_mainPentagonMixin.scss
@@ -1,13 +1,9 @@
-@use "src/lib/style/variables";
+@import "src/lib/style/variables.module";
 @import "src/lib/style/atomicMixin";
 
 @mixin node {
     @include box-shadow-2(rgb(var(--font-color)));
     @include pointer;
-    --node: #{variables.$node_small}px;
-    @media only screen and (min-width: 500px) {
-        --node: #{variables.$node_medium}px;
-    };
     
     width: var(--node);
     height: var(--node);

--- a/src/lib/style/_variables.module.scss
+++ b/src/lib/style/_variables.module.scss
@@ -1,0 +1,54 @@
+$variables: (
+    'break-point-small': 500,
+    'node-small': 36,
+    
+    'break-point-medium': 800,
+    'node-medium': 64,
+
+    'pentagon-radius-multiplier': 3,
+    'pentagon-outer-container-multiplier': 8,
+    'pentagon-inner-component-multiplier': 7.5, 
+    'pentagon-angle-offset': 270
+);
+
+:root {
+    @each $key, $value in $variables {
+        --#{unquote($key)}: #{$value};
+    }
+
+    --font-color: 255, 255, 255;
+    --weak-font-color: 168, 168, 168;
+
+    // 배경 밝기에 따른 적응형 색상 변수
+    --light-font-color: 240, 240, 240;
+    --dark-font-color: 16, 16, 16;
+
+    --background-color: 24, 28, 24;
+    --modal-background: 36, 36, 36;
+    --modal-backdrop: 12, 12, 12;
+
+    --dark-gray: 51, 51, 51;
+    --true-gray: 128, 128, 128;
+
+    --primary: 43, 166, 137;
+    --info: 0, 167, 195;
+    --success: 0, 188, 93;
+    --warning: 243, 133, 0;
+    --danger: 255, 69, 58;
+
+    --base-size: 1rem;
+
+    color: rgb(var(--font-color));
+    background-color: rgb(var(--background-color));
+    font-family: "Wanted Sans Variable";
+    --node: calc(var(--node-small) * 1px);
+    @media only screen and (min-width: 500px) {
+        --node: calc(var(--node-medium) * 1px);
+    };
+};
+
+:export {
+    @each $key, $value in $variables {
+        #{unquote($key)}: $value;
+    }
+}

--- a/src/lib/style/_variables.module.scss.d.ts
+++ b/src/lib/style/_variables.module.scss.d.ts
@@ -1,0 +1,8 @@
+export declare const breakPointMedium: string;
+export declare const breakPointSmall: string;
+export declare const nodeMedium: string;
+export declare const nodeSmall: string;
+export declare const pentagonAngleOffset: string;
+export declare const pentagonInnerComponentMultiplier: string;
+export declare const pentagonOuterContainerMultiplier: string;
+export declare const pentagonRadiusMultiplier: string;

--- a/src/lib/style/_variables.scss
+++ b/src/lib/style/_variables.scss
@@ -1,5 +1,0 @@
-// /variables.ts와 반드시 같이 수정
-$node_small: 36;
-$node_medium: 64;
-
-$pentagon_angle_offset: 270deg;

--- a/src/lib/style/variables.ts
+++ b/src/lib/style/variables.ts
@@ -1,19 +1,18 @@
-// /_variables.scss와 반드시 함께 수정
+import VARIABLES from './_variables.module.scss';
+
 export const STYLE = {
-    BREAK_POINT: {
-        SM: 500,
-        MD: 800,
+    breakPoint: {
+        sm: VARIABLES.breakPointSmall,
+        md: VARIABLES.breakPointMedium,
     },
-    SM: {
-        NODE: 36
+    sm: {
+        node: VARIABLES.nodeSmall
     },
-    MD: {
-        NODE: 64
+    md: {
+        node: VARIABLES.nodeMedium
     },
-    LG: {
-        NODE: 64
+    lg: {
+        node: VARIABLES.nodeMedium
     },
-    COMMON: {
-        PENTAGON_ANGLE_OFFSET: 270,
-    }
+    common: VARIABLES
 }

--- a/src/routes/_auth/pentagram/$pentagramId/update.tsx
+++ b/src/routes/_auth/pentagram/$pentagramId/update.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next';
 import { useThrottle, useThrottledErrorToast } from '$lib/hooks';
 import { useOeuvreNavigate, usePentagramNavigate } from "$feature/navigate/hooks"
+import { useCSSVariables } from '$lib/hooks/useCSSVariables';
 import { 
     useInitialize, 
     useMutationHandler,
@@ -71,7 +72,8 @@ function PentagramUpdate() {
     const errorToast = useThrottledErrorToast()
     const navigate = useNavigate()
     const pentagramNavigate = usePentagramNavigate()
-    const oeuvreNavigate = useOeuvreNavigate();
+    const oeuvreNavigate = useOeuvreNavigate()
+    const STYLE = useCSSVariables()
 
     useInitialize(pentagram)
     useMerge()
@@ -83,7 +85,11 @@ function PentagramUpdate() {
     const parentRef = useRef<HTMLDivElement | null>(null)
     const quadtreeRef = useQuadtreeRef()
 
-    const { handleSelectNode, handleSetNewPosition, handleDragAndTouchMove } = useMainPentagonEventHandler(parentRef, quadtreeRef)
+    const { 
+        handleSelectNode, 
+        handleSetNewPosition, 
+        handleDragAndTouchMove 
+    } = useMainPentagonEventHandler(parentRef, quadtreeRef, STYLE)
 
     const handleSetNewPositionWithErrorToast = (e: MouseEvent<HTMLDivElement>) => {
         const throttled = () => throttle(

--- a/src/routes/_auth/pentagram/create.tsx
+++ b/src/routes/_auth/pentagram/create.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next';
 import { useThrottle, useThrottledErrorToast } from '$lib/hooks';
 import { useOeuvreNavigate, usePentagramNavigate } from "$feature/navigate/hooks"
+import { useCSSVariables } from '$lib/hooks/useCSSVariables';
 import { 
     useMutationHandler,
     useMainPentagonEventHandler, 
@@ -41,6 +42,7 @@ function PentagramInsert() {
     const navigate = useNavigate()
     const pentgramNavigate = usePentagramNavigate()
     const oeuvreNavigate = useOeuvreNavigate();
+    const STYLE = useCSSVariables()
 
     useInitialize(null)
     useMerge()
@@ -52,7 +54,11 @@ function PentagramInsert() {
     const parentRef = useRef<HTMLDivElement | null>(null)
     const quadtreeRef = useQuadtreeRef()
 
-    const { handleSelectNode, handleSetNewPosition, handleDragAndTouchMove } = useMainPentagonEventHandler(parentRef, quadtreeRef)
+    const { 
+        handleSelectNode, 
+        handleSetNewPosition, 
+        handleDragAndTouchMove 
+    } = useMainPentagonEventHandler(parentRef, quadtreeRef, STYLE)
     
     const handleSetNewPositionWithErrorToast = (e: MouseEvent<HTMLDivElement>) => {
         const throttled = () => throttle(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,18 +6,24 @@ import { TanStackRouterVite } from '@tanstack/router-vite-plugin'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [
-    TanStackRouterVite({
-      routeFileIgnorePrefix: '-'
-    }),
-    react(),
-    codegen()
-  ],
-  /* resolve만 담당, ESlint는 TSConfig에서 적용됨 */
-  resolve: {
-    alias: [
-      { find: "$lib", replacement: path.resolve(__dirname, "src/lib") },
-      { find: "$feature", replacement: path.resolve(__dirname, "src/feature") },
+    plugins: [
+        TanStackRouterVite({
+            routeFileIgnorePrefix: '-'
+        }),
+        react(),
+        codegen()
     ],
-  },
+    css: {
+        modules: {
+            localsConvention: 'camelCase',
+        },
+    },
+    
+    /* resolve만 담당, ESlint는 TSConfig에서 적용됨 */
+    resolve: {
+        alias: [
+            { find: "$lib", replacement: path.resolve(__dirname, "src/lib") },
+            { find: "$feature", replacement: path.resolve(__dirname, "src/feature") },
+        ],
+    },
 })


### PR DESCRIPTION
- #24 
- 오각형의 크기가 반응형으로 변경되는 부분에 따라, `반지름의 값`이 변경
    - DB에 보내야 하는 값(각도와 거리)을 계산하기에 필수적인 값을 스크립트만으로 계산할 수 없는 문제
    - `반지름의 값`은 이벤트가 발생한 `currentTarget`의 값과 직접적인 연관성이 없었음
    - 기존에는 임의적 속성을 통해 변수를 전달
- 이러한 경우, 유지 보수가 힘들어지기 때문에 별도의 방법(`미디어-쿼리 훅을 통한 CSS 변수 전달`)을 마련
    - 이 방법에서도 CSS 변수를 이중으로 정의(Scss파일에서, 그리고 ts에서)하는 문제가 존재
    - 이를 css 모듈로 일원화하였음