### PR TITLE
fix: vercel 애널리틱스 미적용 수정 및 컴포넌트 방식으로 롤백

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,9 +8,5 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-    <script>
-      window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
-    </script>
-    <script defer src="/_vercel/insights/script.js"></script>    
-  </body>
+ </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@supabase/storage-js": "^2.5.5",
     "@supabase/supabase-js": "^2.39.3",
     "@tanstack/react-router": "^1.12.2",
+    "@vercel/analytics": "^1.2.2",
     "graphql": "^16.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/lib/layout/Layout.tsx
+++ b/src/lib/layout/Layout.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, ReactNode } from "react"
+import type { PropsWithChildren, ReactNode } from "react"
 import './style/layout.scss'
 
 interface LayoutProps extends PropsWithChildren{

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import { PersistGate } from 'redux-persist/integration/react'
 import { Toaster } from "react-hot-toast"
 import { ApolloProvider } from '@apollo/client'
 
+import { Analytics } from '@vercel/analytics/react';
 import { persistor, store } from "./lib/stores/store.ts"
 import { routeTree } from './routeTree.gen.ts'
 import apolloClient from '$lib/graphql/client.ts'
@@ -40,5 +41,6 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
                 </PersistGate>
             </Provider>
         </ApolloProvider>
+        <Analytics />
     </React.StrictMode>
 )


### PR DESCRIPTION
#### 1. 원인
- `광고 제거 확장` 프로그램 사용으로 인해 클라이언트에서 차단한 내용
- 애널리틱스 스크립트가 차단되는 것은 `기대 행동`과 다르지 않으므로 롤백