### PR TITLE
chore: 펜타그램 등록 및 수정 시, 에러 메시지 출력 방식 변경

### DIFF
--- a/src/feature/Pentagram/error/MutationError.ts
+++ b/src/feature/Pentagram/error/MutationError.ts
@@ -1,0 +1,18 @@
+import { CustomError } from "$lib/error"
+
+export class EmptyInputError extends CustomError {
+    constructor() {
+        super(
+            '생성하려는 펜타그램이 비어있거나 기존 펜타그램과 변화가 없어요.',
+            'pentagram.toast.error.emptyInput'
+        )
+    }
+}
+export class PentagramTransactionError extends CustomError {
+    constructor() {
+        super(
+            '펜타그램 등록에 실패했어요. 같은 문제가 반복될 경우 문의를 남겨주세요.',
+            'pentagram.toast.error.pentagramMutationFailed'
+        )
+    }
+}

--- a/src/feature/Pentagram/error/UpdateError.ts
+++ b/src/feature/Pentagram/error/UpdateError.ts
@@ -17,21 +17,3 @@ export class DuplicateError extends CustomError {
         )
     }
 }
-
-export class UpdatePentagramTransactionError extends CustomError {
-    constructor() {
-        super(
-            '펜타그램 업데이트에 실패했어요. 같은 문제가 반복될 경우 문의를 남겨주세요.',
-            'pentagram.toast.error.updateTransactionFailed'
-        )
-    }
-}
-
-export class InsertPentagramTransactionError extends CustomError {
-    constructor() {
-        super(
-            '펜타그램 등록에 실패했어요. 같은 문제가 반복될 경우 문의를 남겨주세요.',
-            'pentagram.toast.error.insertTransactionFailed'
-        )
-    }
-}

--- a/src/feature/Pentagram/error/index.ts
+++ b/src/feature/Pentagram/error/index.ts
@@ -1,1 +1,2 @@
+export * from './MutationError'
 export * from './UpdateError'

--- a/src/feature/Pentagram/errorHandler/index.ts
+++ b/src/feature/Pentagram/errorHandler/index.ts
@@ -1,0 +1,23 @@
+import { CustomUnknownError } from "$lib/error"
+import { isCustomError, isError } from "$lib/utils"
+import { EmptyInputError, PentagramTransactionError } from "../error/MutationError"
+
+export async function pentagramMutationErrorHandler<T>(func: () => T) {
+    try {
+        const result = await func()
+        return result
+    } catch(e) {
+        if (!isError(e)) {
+            throw new CustomUnknownError()
+        }
+
+        if (e.message === 'empty input') {
+            throw new EmptyInputError()
+        }
+
+        if (isCustomError(e)) {
+            throw e
+        }
+        throw new PentagramTransactionError()
+    }
+}

--- a/src/feature/Pentagram/hooks/eventHandler/mutation/useMutationHandler.ts
+++ b/src/feature/Pentagram/hooks/eventHandler/mutation/useMutationHandler.ts
@@ -8,7 +8,6 @@ import { supabaseClient } from "$lib/supabase";
 import { abortChanges } from "../../../store/pentagramUpsertSlice";
 import { filterChanges, formatChanges } from '../../../utils';
 import { evictCacheById } from "$lib/utils";
-import { InsertPentagramTransactionError, UpdatePentagramTransactionError } from "../../../error";
 import { PendingError } from "$lib/error";
 import { getOeuvreInfoById_QUERY } from "$feature/Oeuvre/graphql";
 import { getUserById_QUERY } from "$feature/auth/graphql";
@@ -43,7 +42,7 @@ export function useMutationHandler() {
             setPending(false)
         }
     
-        if (error) throw new UpdatePentagramTransactionError()
+        if (error) throw error
 
         if (data) {
             evictCacheById({
@@ -84,7 +83,7 @@ export function useMutationHandler() {
             setPending(false)
         }
 
-        if (error) throw new InsertPentagramTransactionError()
+        if (error) throw error
 
         if (data) {
             evictCacheById({

--- a/src/locales/en/pentagram.json
+++ b/src/locales/en/pentagram.json
@@ -16,8 +16,8 @@
         "error": {
             "invalidPosition": "Selected position isn't valid. Please try placing it somewhere else",
             "notUniqueOeuvre": "A duplicate oeuvre already exists in this Pentagram",
-            "insertTransactionFailed": "Pentagram update failed. Please contact us if the same issue persists.", 
-            "updateTransactionFailed": "Pentagram registration failed. Please contact us if the same issue persists."
+            "emptyInput": "The pentagram you are trying to create or update is empty or has no changes.",
+            "pentagramMutationFailed": "Failed to register pentagram. If the same problem persists, please leave an inquiry."
         },
         "loading": {
             "updatePentagram": "Waiting for Pentagram to be updated.",

--- a/src/locales/ko/pentagram.json
+++ b/src/locales/ko/pentagram.json
@@ -16,8 +16,8 @@
         "error": {
             "invalidPosition": "선택한 위치는 선택할 수 없습니다.",
             "notUniqueOeuvre": "중복된 작품이 이 펜타그램에 이미 존재해요",
-            "insertTransactionFailed": "펜타그램 업데이트에 실패했어요. 같은 문제가 반복될 경우 문의를 남겨주세요.", 
-            "updateTransactionFailed": "펜타그램 등록에 실패했어요. 같은 문제가 반복될 경우 문의를 남겨주세요."
+            "emptyInput": "생성하려는 펜타그램이 비어있거나 기존 펜타그램과 변화가 없어요.",
+            "pentagramMutationFailed": "펜타그램 등록에 실패했어요. 같은 문제가 반복될 경우 문의를 남겨주세요."
         },
         "loading": {
             "updatePentagram": "펜타그램 업데이트를 기다리고 있어요.",

--- a/src/routes/_auth/pentagram/$pentagramId/update.tsx
+++ b/src/routes/_auth/pentagram/$pentagramId/update.tsx
@@ -24,6 +24,7 @@ import {
 import toast from 'react-hot-toast';
 import { t as translate } from 'i18next';
 import { Outlet, createFileRoute, redirect } from '@tanstack/react-router'
+import { pentagramMutationErrorHandler } from '$feature/Pentagram/errorHandler';
 import { getPentagramUpdateInfoById_QUERY } from '$feature/Pentagram/graphql';
 import { getFirstNodeOfCollection } from '$lib/utils/graphql';
 
@@ -116,8 +117,15 @@ function PentagramUpdate() {
     }
 
     const { handleUpdatePentagram } = useMutationHandler()
+    
+
     const handleClickSubmit = () => {
-        const response = handleUpdatePentagram(pentagramId)
+        const response = pentagramMutationErrorHandler(
+            async () => {
+                await handleUpdatePentagram(pentagramId)
+            }
+        )
+
         toast.promise(response, {
             loading: t("pentagram.toast.loading.updatePentagram"),
             success: t("pentagram.toast.success.updatePentagram"),

--- a/src/routes/_auth/pentagram/create.tsx
+++ b/src/routes/_auth/pentagram/create.tsx
@@ -21,6 +21,7 @@ import {
 
 import toast from 'react-hot-toast';
 import { t as translate } from 'i18next';
+import { pentagramMutationErrorHandler } from '$feature/Pentagram/errorHandler';
 import { Outlet, createFileRoute } from '@tanstack/react-router'
 
 
@@ -88,7 +89,12 @@ function PentagramInsert() {
 
     const { handleInsertPentagram } = useMutationHandler()
     const handleClickSubmit = () => {
-        const response = handleInsertPentagram()
+        const response = pentagramMutationErrorHandler(
+            async () => {
+                await handleInsertPentagram()
+            }
+        )
+
         toast.promise(response, {
             loading: t("pentagram.toast.loading.createPentagram"),
             success: t("pentagram.toast.success.createPentagram"),


### PR DESCRIPTION
- 기존에는 `DB`에서 `에러 처리`하면 개별화 된 메시지를 전달하는 대신 `일반 에러 메시지` 출력
- 사용자가 무엇이 잘못되었는지 모르고 계속 시도할 수 있음
- 에러에 따라 개별 메시지 출력으로 변경