### PR TITLE
refactor: 무한스크롤 컴포넌트 onLeave 콜백 및 loadkey props추가

### DIFF
--- a/src/feature/Pentagram/components/PentagramCard/SelectMainPentagon/index.tsx
+++ b/src/feature/Pentagram/components/PentagramCard/SelectMainPentagon/index.tsx
@@ -27,7 +27,8 @@ export default function SelectMainPentagon(props: SelectMainPentagonProps) {
     const canvasSize = Number(STYLE.node) * Number(STYLE.pentagonCanvasComponentMultiplier)
     
     const onIntersect = () => setInView(true)
-    useIntersectionObserver(sentinelRef, onIntersect)
+    const onLeave = () => setInView(false)
+    useIntersectionObserver(sentinelRef, onIntersect, onLeave)
 
     return pentagramNodesCollection && (
         <div className="select-main-pentagon-component">
@@ -49,7 +50,7 @@ export default function SelectMainPentagon(props: SelectMainPentagonProps) {
                     />
                 }
             </OeuvrePentagonWrapper>
-            {!inView && <div ref={sentinelRef} className="select-main-pentagon-component__sentinel" />}
+            <div ref={sentinelRef} className="select-main-pentagon-component__sentinel" />
         </div>
     )
 }

--- a/src/lib/components/common/InfiniteScrollTrigger.tsx
+++ b/src/lib/components/common/InfiniteScrollTrigger.tsx
@@ -3,16 +3,17 @@ import { useIntersectionObserver } from "$lib/hooks"
 import LoadingSpinner from "./LoadingSpinner"
 import "./style/infiniteScrollTrigger.scss"
 
-type LoadMoreProps = {
-    handleLoadMore: () => void,
+type LoadMoreProps<T> = {
+    loadKey?: T,
+    handleLoadMore: (key?: T) => void,
     hasNextPage: boolean | undefined
 }
 
-export default function InfiniteScrollTrigger(props: LoadMoreProps) {
-    const { handleLoadMore, hasNextPage } = props
+export default function InfiniteScrollTrigger<T=undefined>(props: LoadMoreProps<T>) {
+    const { loadKey, handleLoadMore, hasNextPage } = props
 
     const onIntersect = () => {
-       hasNextPage && handleLoadMore()
+       hasNextPage && handleLoadMore(loadKey)
     }
 
 	const sentinelRef = useRef<HTMLDivElement>(null);

--- a/src/lib/hooks/useIntersectionObserver.ts
+++ b/src/lib/hooks/useIntersectionObserver.ts
@@ -3,12 +3,20 @@ import { useCallback, useEffect, useRef } from "react";
 
 export function useIntersectionObserver(
     sentinelRef: RefObject<HTMLDivElement>,
-    cb: () => void
+    onEnterCb: () => void,
+    onLeaveCb?: () => void
 ) {
 	const observerRef = useRef<IntersectionObserver | null>(null);
+
     const handleIntersect = useCallback((entries: IntersectionObserverEntry[]) => {
-        if (entries[0].isIntersecting && cb) cb()
-    }, [cb])
+        if (entries[0].isIntersecting && onEnterCb) {
+            onEnterCb()
+        }
+        if (!entries[0].isIntersecting && onLeaveCb) {
+            onLeaveCb()
+        }
+    }, [onEnterCb, onLeaveCb])
+
 
     useEffect(() => {
         observerRef.current = new IntersectionObserver(handleIntersect, {


### PR DESCRIPTION
#### 1. 불필요 렌더링 축소를 위한 onLeave 콜백 추가
- 펜타그램 배경 꾸미기 요소는 50ms마다 실행됨
- 화면 밖에서 실행되는 꾸미기 요소들이 프레임 드랍 유발
- 화면에서 벗어나는 경우 실행을 중단함으로써 프레임 확보 